### PR TITLE
redoing how some of logging is done

### DIFF
--- a/commands_to_load/Paginate.py
+++ b/commands_to_load/Paginate.py
@@ -48,8 +48,8 @@ async def paginateEmbed(bot, ctx, listToEmbed, numOfPages=0, numOfPageEntries=0,
     msg = None
 
     while True:
-        logger.info("[Paginate paginateEmbed()] loading page " + str(currentPage) + " with roles " + str(
-            listOfRoles[currentPage]))
+        logger.info("[Paginate paginateEmbed()] loading page " + str(currentPage))
+        logger.info("[Paginate paginateEmbed()] loading roles " + str(listOfRoles[currentPage]))
         embed = discord.Embed(title=title, color=0x81e28d)
         for x in listOfRoles[currentPage]:
             if x[0] != "":
@@ -151,7 +151,8 @@ async def paginate(bot, ctx, listToPaginate, numOfPages=0, numOfPageEntries=0, t
     firstRun = True
     msg = None
     while True:
-        logger.info("[Paginate paginate()] loading page " + str(currentPage) + " with roles " + str(listOfRoles))
+        logger.info("[Paginate paginate()] loading page " + str(currentPage))
+        logger.info("[Paginate paginate()] loading roles " + str(listOfRoles[currentPage]))
         output = title + "\n\n```"
         for x in listOfRoles[currentPage]:
             if x != '':


### PR DESCRIPTION
done to avoid a situation where the output isnt helpful on what the number was that was not able to be used as an index

.2018-09-14 03:47:21 = WARNING - Traceback (most recent call last):
.2018-09-14 03:47:21 = WARNING -
.2018-09-14 03:47:21 = WARNING -   File "/usr/local/lib/python3.5/site-packages/discord/ext/commands/core.py", line 62, in wrapped
.    ret = yield from coro(*args, **kwargs)
.2018-09-14 03:47:21 = WARNING -
.2018-09-14 03:47:21 = WARNING -   File "/usr/src/app/commands_to_load/HealthChecks.py", line 69, in help
.    await paginateEmbed(bot=self.bot,title="Help Page" ,ctx=ctx,listToEmbed=helpArr, numOfPageEntries=5)
.2018-09-14 03:47:21 = WARNING -
.2018-09-14 03:47:21 = WARNING -   File "/usr/src/app/commands_to_load/Paginate.py", line 52, in paginateEmbed
.    listOfRoles[currentPage]))
.2018-09-14 03:47:21 = WARNING -
.2018-09-14 03:47:21 = WARNING - IndexError: list index out of range
.2018-09-14 03:47:21 = WARNING -
.2018-09-14 03:47:21 = WARNING -
.The above exception was the direct cause of the following exception:
.2018-09-14 03:47:21 = WARNING -
.2018-09-14 03:47:21 = WARNING - Traceback (most recent call last):
.2018-09-14 03:47:21 = WARNING -
.2018-09-14 03:47:21 = WARNING -   File "/usr/local/lib/python3.5/site-packages/discord/ext/commands/bot.py", line 886, in invoke
.    yield from ctx.command.invoke(ctx)
.2018-09-14 03:47:21 = WARNING -
.2018-09-14 03:47:21 = WARNING -   File "/usr/local/lib/python3.5/site-packages/discord/ext/commands/core.py", line 498, in invoke
.    yield from injected(*ctx.args, **ctx.kwargs)
.2018-09-14 03:47:21 = WARNING -
.2018-09-14 03:47:21 = WARNING -   File "/usr/local/lib/python3.5/site-packages/discord/ext/commands/core.py", line 71, in wrapped
.    raise CommandInvokeError(e) from e