### PR TITLE
Fixed embed command so the fields and everything appear in an embed

### DIFF
--- a/helper_files/embed.py
+++ b/helper_files/embed.py
@@ -25,5 +25,5 @@ def embed(title='', content='', description='', author='', colour=0x00bfbd, link
     #embObj.url = link
     #parse content to add fields
     for x in content:
-        embObj.add_field(name=x[0], value=x[1], inline=True)
+        embObj.add_field(name=x[0], value=x[1], inline=False)
     return embObj


### PR DESCRIPTION
appear above and below one another. This was originally an oversight