### PR TITLE
Sfu Cog Fixes

### DIFF
--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -104,8 +104,13 @@ class SFU():
             logger.info('[SFU outline()] missing arguments, command ended')
             return
 
-        year = 'current'
-        term = 'current'
+        if 'next' in course:
+            year = 'registration'
+            term = 'registration'
+            course = course[:len(course) - 1]
+        else:
+            year = 'current'
+            term = 'current'
 
         courseCode = ''
         courseNum = ''

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -62,14 +62,20 @@ class SFU():
         async with aiohttp.ClientSession() as req:
             res = await req.get(url)
 
-        if(res.status == 200):
-            logger.info('[SFU sfu()] get request successful')
-            data = await res.json()
-        else:
-            logger.info('[SFU sfu()] get resulted in ' + str(res.status))
-            eObj = embed(title='Results from SFU', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, colour=sfuRed, description='Couldn\'t find anything for:\n%s/%s/%s/%s/\nMake sure you entered all the arguments correctly' % (year, term.upper(), courseCode.upper(), courseNum), footer='SFU Error')
-            await ctx.send(embed=eObj)
-            return
+            if(res.status == 200):
+                logger.info('[SFU sfu()] get request successful')
+                data = ''
+                while True:
+                    chunk = await res.content.read(10)
+                    if not chunk:
+                        break
+                    data += str(chunk.decode())
+                data = json.loads(data)
+            else:
+                logger.info('[SFU sfu()] get resulted in ' + str(res.status))
+                eObj = embed(title='Results from SFU', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, colour=sfuRed, description='Couldn\'t find anything for:\n%s/%s/%s/%s/\nMake sure you entered all the arguments correctly' % (year, term.upper(), courseCode.upper(), courseNum), footer='SFU Error')
+                await ctx.send(embed=eObj)
+                return
         
         logger.info('[SFU sfu()] parsing json data returned from get request')
         title = 'Results from SFU'

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -94,8 +94,8 @@ class SFU():
         logger.info('[SFU outline()] arguments given: ' + str(course))
         
         usage = [
-                ['Usage', '`.outline <course> [<term> <section>]`\n*<term> and <section> are optional arguments*'], 
-                ['Example', '`.outline cmpt300 fall d200`']
+                ['Usage', '`.outline <course> [<term> <section> <next>]`\n*<term> and <section> are optional arguments*\nInclude the keyword `next` at the end to look at the next semester, this is for course registration purposes.'], 
+                ['Example', '`.outline cmpt300\n cmpt300 fall\n cmpt300  d200`']
             ]
 
         if(not course):
@@ -103,11 +103,11 @@ class SFU():
             await ctx.send(embed=eObj)
             logger.info('[SFU outline()] missing arguments, command ended')
             return
-
+        course = list(course)
         if 'next' in course:
             year = 'registration'
             term = 'registration'
-            course = course[:len(course) - 1]
+            course.remove('next')
         else:
             year = 'current'
             term = 'current'
@@ -138,36 +138,37 @@ class SFU():
                 logger.info('[SFU outline()] bad arguments, command ended')
                 return
 
-            courseCode = crs[0]
+            courseCode = crs[0].lower()
             courseNum = crs[1]
 
         # Course and term or section is specified
         if(argNum == 2):
             # Figure out if section or term was given
             temp = course[1].lower()
-
-            if(len(temp) == 4):
-                if(temp != 'fall'):
-                    section = temp
-                else:
+            if temp[3].isdigit():
+                section = temp
+            elif term != 'registration':
+                if(temp == 'fall'):
                     term = temp
-            elif(temp == 'summer'):
-                term = temp
-            elif(temp == 'spring'):
-                term = temp
+                elif(temp == 'summer'):
+                    term = temp
+                elif(temp == 'spring'):
+                    term = temp
         
         # Course, term, and section is specified
         elif(argNum == 3):
-            # Check iff last arg is section
-            if(len(course[2]) == 4 and (course[1] == 'fall' or course[1] == 'spring' or course[1] == 'summer')):
-                term = course[1].lower()
+            # Check if last arg is section
+            if course[2][3].isdigit():
                 section = course[2].lower()
-            else:
-                # Send something saying be in this order
-                logger.error('[SFU outline] args out of order or wrong')
-                eObj = embed(title='Bad Arguments', author=settings.BOT_NAME, avatar=settings.BOT_NAME, colour=sfuRed, description='Make sure your arguments are in the following order:\n<course> <term> <section>\nexample: `.outline cmpt300 fall d200`\n term and section are optional args', footer='SFU Outline Error')
-                await ctx.send(embed=eObj)
-                return
+            if term != 'registration':
+                if course[1] == 'fall' or course[1] == 'spring' or course[1] == 'summer':
+                    term = course[1].lower()
+                else:
+                    # Send something saying be in this order
+                    logger.error('[SFU outline] args out of order or wrong')
+                    eObj = embed(title='Bad Arguments', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, colour=sfuRed, description='Make sure your arguments are in the following order:\n<course> <term> <section>\nexample: `.outline cmpt300 fall d200`\n term and section are optional args', footer='SFU Outline Error')
+                    await ctx.send(embed=eObj)
+                    return
 
         # Set up url for get
         url = 'http://www.sfu.ca/bin/wcm/course-outlines?%s/%s/%s/%s/%s' % (year, term, courseCode, courseNum, section)

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -178,6 +178,22 @@ class SFU():
                     return
 
         # Set up url for get
+        if section == '':
+            # get req the section
+            logger.info('[SFU outline()] getting section')
+            res = await self.req.get('http://www.sfu.ca/bin/wcm/course-outlines?%s/%s/%s/%s' % (year, term, courseCode, courseNum))
+            if(res.status == 200):
+                data = ''
+                while not res.content.at_eof():
+                    chunk = await res.content.readchunk()
+                    data += str(chunk.decode())
+                res = json.loads(data)
+                logger.info('[SFU outline()] parsing section data')
+                for x in res:
+                    if x['sectionCode'] in ['LEC', 'LAB', 'TUT']:
+                        section = x['value']
+                        break
+
         url = 'http://www.sfu.ca/bin/wcm/course-outlines?%s/%s/%s/%s/%s' % (year, term, courseCode, courseNum, section)
         logger.info('[SFU outline()] url for get constructed: ' + url)
 
@@ -193,7 +209,7 @@ class SFU():
             data = json.loads(data)
         else:
             logger.error('[SFU outline()] get resulted in '+ str(res.status))
-            eObj = embed(title='SFU Course Outlines', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, colour=sfuRed, description='Couldn\'t find anything for:\n`' + courseCode.upper() + ' ' + str(courseNum).upper() + '`', footer='SFU Outline Error')
+            eObj = embed(title='SFU Course Outlines', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, colour=sfuRed, description='Couldn\'t find anything for `' + courseCode.upper() + ' ' + str(courseNum).upper() + '`\n Maybe the course doesn\'t exist? Or isn\'t offerend right now.', footer='SFU Outline Error')
             await ctx.send(embed=eObj)
             return
 
@@ -252,7 +268,7 @@ class SFU():
             prerequisites = 'None'
 
         try:
-            corequisites  = data['info']['corequisites'] or 'None'
+            corequisites  = data['info']['corequisites']
         except Exception:
             corequisites = ''
 
@@ -277,7 +293,7 @@ class SFU():
         fields.append(['URL', '[here](%s)' % url])
         
         img = 'http://www.sfu.ca/content/sfu/clf/jcr:content/main_content/image_0.img.1280.high.jpg/1468454298527.jpg'
-
+        
         eObj = embed(title='SFU Outline Results', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, colour=sfuRed, thumbnail=img, content=fields, footer='Written by VJ')
         await ctx.send(embed=eObj)
 

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -241,7 +241,11 @@ class SFU():
         except Exception:
             details = 'None'
         
-        prerequisites  = data['info']['prerequisites'] or "None"
+        try:
+            prerequisites  = data['info']['prerequisites'] or 'None'
+        except Exception:
+            prerequisites = 'None'
+
 
         url = 'http://www.sfu.ca/outlines.html?%s' % data['info']['outlinePath']
         

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -79,8 +79,6 @@ class SFU():
                 return
         
         logger.info('[SFU sfu()] parsing json data returned from get request')
-        title = 'Results from SFU'
-        colour = sfuRed
 
         sfuUrl='http://www.sfu.ca/students/calendar/%s/%s/courses/%s/%s.html' % (year, term, courseCode, courseNum)
         link = '[here](%s)' % sfuUrl
@@ -91,7 +89,7 @@ class SFU():
             ["URL", link]
         ]
 
-        embedObj = embed(title='Results from SFU', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, content=fields, colour=colour, footer=footer)
+        embedObj = embed(title='Results from SFU', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, content=fields, colour=sfuRed, footer=footer)
         await ctx.send(embed=embedObj)
         logger.info('[SFU sfu()] out sent to server')        
 

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -94,7 +94,7 @@ class SFU():
         logger.info('[SFU outline()] arguments given: ' + str(course))
         
         usage = [
-                ['Usage', '`.outline <course> [<term> <section> <next>]`\n*<term> and <section> are optional arguments*\nInclude the keyword `next` at the end to look at the next semester, this is for course registration purposes.'], 
+                ['Usage', '`.outline <course> [<term> <section> <next>]`\n*<term> and <section> are optional arguments*\nInclude the keyword `next` to look at the next semester\'s outline, this is for course registration purposes.'], 
                 ['Example', '`.outline cmpt300\n cmpt300 fall\n cmpt300  d200`']
             ]
 
@@ -177,14 +177,20 @@ class SFU():
         async with aiohttp.ClientSession() as req:
             res = await req.get(url)
 
-        if(res.status == 200):
-            logger.info('[SFU outline()] get request successful')
-            data = await res.json()
-        else:
-            logger.error('[SFU outline()] get resulted in '+ str(res.status))
-            eObj = embed(title='SFU Course Outlines', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, colour=sfuRed, description='Couldn\'t find anything for:\n`' + courseCode + ' ' + courseNum + '`', footer='SFU Outline Error')
-            await ctx.send(embed=eObj)
-            return
+            if(res.status == 200):
+                logger.info('[SFU outline()] get request successful')
+                data = ''
+                while True:
+                    chunk = await res.content.read(10)
+                    if not chunk:
+                        break
+                    data += str(chunk.decode())
+                data = json.loads(data)
+            else:
+                logger.error('[SFU outline()] get resulted in '+ str(res.status))
+                eObj = embed(title='SFU Course Outlines', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, colour=sfuRed, description='Couldn\'t find anything for:\n`' + courseCode.upper() + ' ' + str(courseNum).upper() + '`', footer='SFU Outline Error')
+                await ctx.send(embed=eObj)
+                return
 
         logger.info('[SFU outline()] parsing data from get request')
         outline = data['info']['outlinePath'].upper()

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -105,7 +105,7 @@ class SFU():
             return
 
         year = 'current'
-        term = 'registration'
+        term = 'current'
 
         courseCode = ''
         courseNum = ''

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -94,8 +94,8 @@ class SFU():
         logger.info('[SFU outline()] arguments given: ' + str(course))
         
         usage = [
-                ['Usage', '`.outline <course> [<term> <section> <next>]`\n*<term> and <section> are optional arguments*\nInclude the keyword `next` to look at the next semester\'s outline, this is for course registration purposes.'], 
-                ['Example', '`.outline cmpt300\n cmpt300 fall\n cmpt300  d200`']
+                ['Usage', '`.outline <course> [<term> <section> <next>]`\n*<term>, <section>, and <next> are optional arguments*\nInclude the keyword `next` to look at the next semester\'s outline. Note: `next` is used for course registration purposes and if the next semester info isn\'t available it\'ll return an error.'], 
+                ['Example', '`.outline cmpt300\n .outline cmpt300 fall\n .outline cmpt300 d200\n .outline cmpt300 spring d200\n .outline cmpt300 next`']
             ]
 
         if(not course):

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -50,10 +50,10 @@ class SFU():
                 logger.info('[SFU outline()] bad arguments, command ended')
                 return
             
-            courseCode = crs[0]
+            courseCode = crs[0].lower()
             courseNum = crs[1]
         else:
-            courseCode = course[0]
+            courseCode = course[0].lower()
             courseNum = course[1]
 
         url = 'http://www.sfu.ca/bin/wcm/academic-calendar?%s/%s/courses/%s/%s' % (year, term, courseCode, courseNum)

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -121,7 +121,7 @@ class SFU():
 
         courseCode = ''
         courseNum = ''
-        section = 'd100'
+        section = ''
         
         logger.info('[SFU outline()] parsing args')
         argNum = len(course)
@@ -186,11 +186,10 @@ class SFU():
         if(res.status == 200):
             logger.info('[SFU outline()] get request successful')
             data = ''
-            while True:
-                chunk = await res.content.read(10)
-                if not chunk:
-                    break
+            while not res.content.at_eof():
+                chunk = await res.content.readchunk()
                 data += str(chunk.decode())
+
             data = json.loads(data)
         else:
             logger.error('[SFU outline()] get resulted in '+ str(res.status))

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -100,7 +100,7 @@ class SFU():
         logger.info('[SFU outline()] arguments given: ' + str(course))
         
         usage = [
-                ['Usage', '`.outline <course> [<term> <section> <next>]`\n*<term>, <section>, and <next> are optional arguments*\nInclude the keyword `next` to look at the next semester\'s outline. Note: `next` is used for course registration purposes and if the next semester info isn\'t available it\'ll return an error.'], 
+                ['Usage', '`.outline <course> [<term> <section> next]`\n*<term>, <section>, and next are optional arguments*\nInclude the keyword `next` to look at the next semester\'s outline. Note: `next` is used for course registration purposes and if the next semester info isn\'t available it\'ll return an error.'], 
                 ['Example', '`.outline cmpt300\n .outline cmpt300 fall\n .outline cmpt300 d200\n .outline cmpt300 spring d200\n .outline cmpt300 next`']
             ]
 

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -246,6 +246,10 @@ class SFU():
         except Exception:
             prerequisites = 'None'
 
+        try:
+            corequisites  = data['info']['corequisites'] or 'None'
+        except Exception:
+            corequisites = ''
 
         url = 'http://www.sfu.ca/outlines.html?%s' % data['info']['outlinePath']
         
@@ -260,9 +264,13 @@ class SFU():
             ['Exam Times', examTimes], 
             ['Description', description], 
             ['Details', details], 
-            ['Prerequisites', prerequisites], 
-            ['URL', '[here](%s)' % url]
+            ['Prerequisites', prerequisites]
         ]
+
+        if corequisites:
+            fields.append(['Corequisites', corequisites])
+        fields.append(['URL', '[here](%s)' % url])
+        
         img = 'http://www.sfu.ca/content/sfu/clf/jcr:content/main_content/image_0.img.1280.high.jpg/1468454298527.jpg'
 
         eObj = embed(title='SFU Outline Results', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, colour=sfuRed, thumbnail=img, content=fields, footer='Written by VJ')

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -241,15 +241,7 @@ class SFU():
         except Exception:
             details = 'None'
         
-        try:
-            prerequisites  = data['info']['prerequisites'] or "None" # try catch this and check for coreq's
-        except Exception:
-            prerequisites = "None"
-
-        try:
-            corequisites  = data['info']['corequisites'] or "None" # try catch this and check for coreq's
-        except Exception:
-            corequisites = ""
+        prerequisites  = data['info']['prerequisites'] or "None"
 
         url = 'http://www.sfu.ca/outlines.html?%s' % data['info']['outlinePath']
         

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -241,7 +241,15 @@ class SFU():
         except Exception:
             details = 'None'
         
-        prerequisites  = data['info']['prerequisites'] or "None"
+        try:
+            prerequisites  = data['info']['prerequisites'] or "None" # try catch this and check for coreq's
+        except Exception:
+            prerequisites = "None"
+
+        try:
+            corequisites  = data['info']['corequisites'] or "None" # try catch this and check for coreq's
+        except Exception:
+            corequisites = ""
 
         url = 'http://www.sfu.ca/outlines.html?%s' % data['info']['outlinePath']
         

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -221,10 +221,13 @@ class SFU():
         # Other details
         # need to cap len for details
         description = data['info']['description']
-        details = html.unescape(data['info']['courseDetails'])
-        details = re.sub('<[^<]+?>', '', details)
-        if(len(details) > 200):
-            details = details[:200] + '\n(...)'
+        try:
+            details = html.unescape(data['info']['courseDetails'])
+            details = re.sub('<[^<]+?>', '', details)
+            if(len(details) > 200):
+                details = details[:200] + '\n(...)'
+        except Exception:
+            details = 'None'
         
         prerequisites  = data['info']['prerequisites'] or "None"
 

--- a/commands_to_load/SFU.py
+++ b/commands_to_load/SFU.py
@@ -214,12 +214,31 @@ class SFU():
             return
 
         logger.info('[SFU outline()] parsing data from get request')
-        outline = data['info']['outlinePath'].upper()
-        title = data['info']['title']
-        instructor = data['instructor'][0]['name'] + '\n[' + data['instructor'][0]['email'] + ']'
+        try:
+            # Main course information 
+            info = data['info']
+
+            # Course schedule information
+            schedule = data['courseSchedule']
+        except Exception:
+            logger.info('[SFU outline()] info keys didn\'t exist')
+            eObj = embed(title='SFU Course Outlines', author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, colour=sfuRed, description='Couldn\'t find anything for `' + courseCode.upper() + ' ' + str(courseNum).upper() + '`\n Maybe the course doesn\'t exist? Or isn\'t offerend right now.', footer='SFU Outline Error')
+            await ctx.send(embed=eObj)
+            return
+
+        outline = info['outlinePath'].upper()
+        title = info['title']
+        try:
+            #instructor = data['instructor'][0]['name'] + '\n[' + data['instructor'][0]['email'] + ']'
+            instructor = ''
+            instructors = data['instructor']
+            for prof in instructors:
+                instructor += prof['name'] 
+                instructor += ' [%s]\n' % prof['email']
+        except Exception:
+            instructor = 'TBA'
         
-        # Course schedule info
-        schedule = data['courseSchedule']
+        # Course schedule info parsing
         crs = ''
         for x in schedule:
             # [LEC] days time, room, campus
@@ -233,7 +252,7 @@ class SFU():
         classTimes = crs
 
         # Exam info
-        examTimes = 'N/A'
+        examTimes = 'TBA'
         roomInfo = ''
         tim = ''
         date = ''

--- a/commands_to_load/help.json
+++ b/commands_to_load/help.json
@@ -40,7 +40,7 @@
 
 		{"access": "role", "role" : "Bot_manager", "name":"Class: SFU"},
 		{"access": "role", "role" : "public", "name": ".sfu <arg>", "description": "Returns the calendar description from current semester of <arg>"},
-		{"access": "role", "role" : "public", "name": ".outline <arg0> [<arg1> <arg2> <next>]", "description": "Returns outline details of course `<arg0>`. Defaults to current term and section d100. Optionally, you may specify term in `<arg1>` and/or section with `<arg2>`. Added keyword `next` will look at next semesters oultine for `<arg0>`;Note this will return error if it is not registration time."}
+		{"access": "role", "role" : "public", "name": ".outline <arg0> [<arg1> <arg2> next]", "description": "Returns outline details of course `<arg0>`. Defaults to current term and section d100. Optionally, you may specify term in `<arg1>` and/or section with `<arg2>`. Added keyword `next` will look at next semesters oultine for `<arg0>`;Note `next` will return error if it is not registration time."}
 		
 	]
 }

--- a/commands_to_load/help.json
+++ b/commands_to_load/help.json
@@ -38,7 +38,7 @@
 
 		{"access": "Bot_manager", "name":"Class: SFU"},
 		{"access": "public", "name": ".sfu <arg>", "description": "Returns the calendar description from current semester of <arg>"},
-		{"access": "public", "name": ".outline <arg0> [<arg1> <arg2>]", "description": "Returns outline details of course `<arg0>`. Defaults to current term and section d100. Optionally, you may specify term in `<arg1>` and/or section with `<arg2>`."}
+		{"access": "public", "name": ".outline <arg0> [<arg1> <arg2> <next>]", "description": "Returns outline details of course `<arg0>`. Defaults to current term and section d100. Optionally, you may specify term in `<arg1>` and/or section with `<arg2>`. Added keyword `next` will look at next semesters oultine for `<arg0>`;Note this will return error if it is not registration time."}
 		
 	]
 }

--- a/commands_to_load/help.json
+++ b/commands_to_load/help.json
@@ -40,7 +40,7 @@
 
 		{"access": "role", "role" : "Bot_manager", "name":"Class: SFU"},
 		{"access": "role", "role" : "public", "name": ".sfu <arg>", "description": "Returns the calendar description from current semester of <arg>"},
-		{"access": "role", "role" : "public", "name": ".outline <arg0> [<arg1> <arg2>]", "description": "Returns outline details of course `<arg0>`. Defaults to current term and section d100. Optionally, you may specify term in `<arg1>` and/or section with `<arg2>`."}
+		{"access": "role", "role" : "public", "name": ".outline <arg0> [<arg1> <arg2> <next>]", "description": "Returns outline details of course `<arg0>`. Defaults to current term and section d100. Optionally, you may specify term in `<arg1>` and/or section with `<arg2>`. Added keyword `next` will look at next semesters oultine for `<arg0>`;Note this will return error if it is not registration time."}
 		
 	]
 }

--- a/commands_to_load/help.json
+++ b/commands_to_load/help.json
@@ -38,9 +38,9 @@
 		{"access": "role", "role" : "Bot_manager", "name": "Class: Here"},
 		{ "access": "role", "role" : "public", "name": ".here <filters> ...", "description": "Displays all users with permissions to view the current channel. Results can be filter by looking for users whose username or nickname on the server contains the substring indicated with any of the included strings or all users if no args are given. Multiple may be entered."},
 
-		{"access": "Bot_manager", "name":"Class: SFU"},
-		{"access": "public", "name": ".sfu <arg>", "description": "Returns the calendar description from current semester of <arg>"},
-		{"access": "public", "name": ".outline <arg0> [<arg1> <arg2> <next>]", "description": "Returns outline details of course `<arg0>`. Defaults to current term and section d100. Optionally, you may specify term in `<arg1>` and/or section with `<arg2>`. Adding keyword `next` will look at next semesters oultine for `<arg0>`;Note this will return error if it is not registration time."}
+		{"access": "role", "role" : "Bot_manager", "name":"Class: SFU"},
+		{"access": "role", "role" : "public", "name": ".sfu <arg>", "description": "Returns the calendar description from current semester of <arg>"},
+		{"access": "role", "role" : "public", "name": ".outline <arg0> [<arg1> <arg2>]", "description": "Returns outline details of course `<arg0>`. Defaults to current term and section d100. Optionally, you may specify term in `<arg1>` and/or section with `<arg2>`."}
 		
 	]
 }

--- a/documentation/Working_on_the_Bot.md
+++ b/documentation/Working_on_the_Bot.md
@@ -134,6 +134,9 @@ These are the things you need to ensure are covered in your PR, otherwise the CO
 1. `.outline cmpt 300`
 1. `.outline cmpt300 spring d200`
 1. `.outline cmpt 300 spring d200`
+1. `.outline cmpt300 next`
+1. `.outline cmpt300 d200 next`
+1. `.outline cmpt300 summer d200 next`
 1. `.outline cmpt666`
 1. `.outline blah`
 1. `.outline`


### PR DESCRIPTION
# SFU Cog Edge Cases, Fixes, and slight improvements 

## Get request fixes
SFU api sometimes will return data as a whole or chunked. Requests could handle either no problem with its json() method but aiohttp's json() method couldnt. So I switched the `outline` and `sfu` commands to read in the data as if it were chunked; So it reads in 10 bytes at a time and decodes them and loads the json data.

## API URL Keyword problem
Mix up of key words `registration` and `current` caused some data to be pulled from the wrong semester

## Next functionality in outline command
The keyword fix highlighted this idea and so if the keyword `next` is included in the users args it'll look to the next semester. Logic in the command has been updated to work with this functionality. The command will return and error if `next` is used when it is not registration time, since the outlines won't exist.

### Updated all the things like test cases and help.json