### PR TITLE
Updated current commands section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,16 @@ Wall-E, named after the lovable character [Wall-E](https://en.wikipedia.org/wiki
 * `.purgeroles` - purges empty self-assignable roles
 * `.here [<filter>]` - displays all users with permissions to view the current channel. Results can be filtered by looking for users whose username or nickname on the server contains the substring indicated with any of the included `<filter>` strings or all users if no filters are given. Multiple `<filters>` may be entered.
 * `.poll <arg>` - starts a yes/no poll where `<arg>` is the question
-* `.poll <arg0> <arg1> <arg2>` (up to 12 arguments) - starts a poll where `<arg0>` is the question and the remaining arguments are the options
-* `.remindmein <arg0> to <arg1>` - created a reminder from `<arg0>` from now with the message `<arg1>`
+* `.poll <arg0> <arg1> <arg2> ... <arg11>` (up to 12 arguments) - starts a poll where `<arg0>` is the question and the remaining arguments are the options
+* `.remindmein <arg0> <units> to <arg1>` - created a reminder for `<arg0>` units from now with the message `<arg1>`, where units can be seconds, minutes, hours, days, months, or years.
+   * Usage examples:
+      * `.remindmein 10 minutes to do homework`
+      * `.remindmein 2 hours to do laundry`
+      * `.remindmein 5 days to finish assignment`
+      
 * `showreminders` - displays all of the invoking user's reminders and their corresponding messageID
 * `deletereminder <arg>` - deletes the reminder that the invoking user created that has the messageId `<arg>`
-* `.urban <arg0>` - return definition from urban dictionary of `<arg0>`
+* `.urban <arg>` - return definition from urban dictionary of `<arg>`
 * `.wolfram <arg>` - returns the result of passing `<arg>` to Wolfram Alpha
 * `.urban <arg>` - returns defintion of `<arg>` along with a link to the definition on urban dictionary
 * `.sfu <arg0>` - returns calendar description from current semesters calendar of `<arg0>`


### PR DESCRIPTION
* Improved clarity of multi argument polls description
* Improved clarity of remindmein description
-added which time units can be used
-added usage examples
* brought urban command description in line with the rest of commands
- changed `arg0` to `arg`

--
This edit is done as part of an assignment for CMPT 376W