### PR TITLE
Fix issues with commandstats

### DIFF
--- a/main.py
+++ b/main.py
@@ -268,7 +268,10 @@ async def on_command(ctx):
 			current_hour=str(now.hour)
 			channel_id=str(ctx.channel.id)
 			channel_name=str(ctx.channel).replace("\'","[single_quote]").strip()
-			author=str(ctx.message.author).replace("\'","[single_quote]").strip()
+			if ctx.guild.get_member(ctx.message.author.id).name.isalnum():
+				author=str(ctx.message.author).replace("\'","[single_quote]").strip()
+			else:
+				author="<"+str(ctx.message.author.id).replace("\'","[single_quote]").strip()+">"
 			command=str(ctx.command).replace("\'","[single_quote]").strip()
 			argument=str(argument).replace("\'","[single_quote]").strip() if command is not "embed" else "redacted due to large size"
 			method_of_invoke=str(ctx.invoked_with).replace("\'","[single_quote]").strip()

--- a/main.py
+++ b/main.py
@@ -254,7 +254,6 @@ async def on_command(ctx):
 			conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
 			curs = conn.cursor()
 			index=0
-			argument=''
 			for arg in ctx.args:
 				if index > 1:
 					argument += arg+' '

--- a/main.py
+++ b/main.py
@@ -267,12 +267,12 @@ async def on_command(ctx):
 			current_day=str(now.day)
 			current_hour=str(now.hour)
 			channel_id=str(ctx.channel.id)
-			channel_name=str(ctx.channel)
-			author=str(ctx.message.author)
-			command=str(ctx.command).strip()
-			argument=str(argument).strip() if command is not "embed" else "redacted due to large size"
-			method_of_invoke=str(ctx.invoked_with).strip()
-			invoked_subcommand=str(ctx.invoked_subcommand).strip()
+			channel_name=str(ctx.channel).replace("\'","[single_quote]").strip()
+			author=str(ctx.message.author).replace("\'","[single_quote]").strip()
+			command=str(ctx.command).replace("\'","[single_quote]").strip()
+			argument=str(argument).replace("\'","[single_quote]").strip() if command is not "embed" else "redacted due to large size"
+			method_of_invoke=str(ctx.invoked_with).replace("\'","[single_quote]").strip()
+			invoked_subcommand=str(ctx.invoked_subcommand).replace("\'","[single_quote]").strip()
 
 			#this next part is just setup to keep inserting until it finsd a primary key that is not in use
 			successful=False

--- a/main.py
+++ b/main.py
@@ -257,8 +257,6 @@ async def on_command(ctx):
 			argument=''
 			for arg in ctx.args:
 				if index > 1:
-					if ',' in arg:
-						arg = arg.replace(',', '[comma]')
 					argument += arg+' '
 				index+=1
 			epoch_time = str(int(time.time()))
@@ -269,8 +267,8 @@ async def on_command(ctx):
 			current_day=str(now.day)
 			current_hour=str(now.hour)
 			channel_id=str(ctx.channel.id)
-			channel_name=str(ctx.channel).replace(",","[comma]").strip()
-			author=str(ctx.message.author).replace(",","[comma]").strip()
+			channel_name=str(ctx.channel)
+			author=str(ctx.message.author)
 			command=str(ctx.command).strip()
 			argument=str(argument).strip() if command is not "embed" else "redacted due to large size"
 			method_of_invoke=str(ctx.invoked_with).strip()


### PR DESCRIPTION
fixing the following issues
 

- Since the storage for the stats command has been changed from a csv to a database, the character that needs to be cleaned out of the insertion is now a `'` instead of a `,`

- fixing issue that may occur when 2 things are gonna try and get inserted into the database with the exact same epoch time

- checking to ensure that each command's author username is only alphanumeric, and in cases where it isnt, using their ID instead