### PR TITLE
Fix help bug

### DIFF
--- a/commands_to_load/Misc.py
+++ b/commands_to_load/Misc.py
@@ -3,6 +3,7 @@ import logging
 import aiohttp
 from helper_files.embed import embed 
 from helper_files.Paginate import paginateEmbed
+from helper_files.listOfRoles import getListOfUserPerms
 import helper_files.settings as settings
 import json
 import wolframalpha
@@ -155,7 +156,7 @@ class Misc():
 		with open('commands_to_load/help.json') as f:
 			helpDict = json.load(f)
 		logger.info("[Misc help()] loaded commands from help.json=\n"+str(json.dumps(helpDict, indent=3)))
-		
+		user_roles = await getListOfUserPerms(ctx)
 		# determing the number of commands the user has access to.
 		numberOfCommands=0
 		for entry in helpDict['commands']:
@@ -169,11 +170,13 @@ class Misc():
 				elif entry['role'] == "public":
 					if 'Class' not in entry['name']:
 						numberOfCommands += 1
-			elif entry['access'] == "channel": ## if the access for the command is determined on permissions
-			## in the channel that the help comamnd was called from, rather than generic role permissions
-				if entry['channel'] in (item[0] for item in list(ctx.channel.permissions_for(ctx.message.author))):
-					if 'Class' not in entry['name']:
-						numberOfCommands += 1	
+			elif entry['access'] == "permissions": ## if the access for the command is determined on permissions
+				print("list of roles for user "+str(ctx.message.author)+" :"+str(user_roles))
+				
+				for permission in entry[entry['access']]:
+					if permission in user_roles:
+						if 'Class' not in entry['name']:
+							numberOfCommands += 1	
 
 		logger.info("[Misc help()] numberOfCommands set to "+str(numberOfCommands))
 		descriptionToEmbed=[""]
@@ -216,15 +219,16 @@ class Misc():
 							descriptionToEmbed.append("")
 							page+=1
 							x = 0
-			elif entry['access'] == "channel":
-				if entry['channel'] in (item[0] for item in list(ctx.channel.permissions_for(ctx.message.author)) if item[1]):
-					logger.info("[Misc help()] adding "+str(entry)+" to page "+str(page)+" of the descriptionToEmbed")					
-					descriptionToEmbed[page]+="*"+entry['name']+"* - "+entry['description']+"\n\n"
-					x+=1
-					if x == numberOfCommandsPerPage:
-						descriptionToEmbed.append("")
-						page+=1
-						x = 0				
+			elif entry['access'] == "permissions":
+				for permission in entry[entry['access']]:
+					if permission in user_roles:
+						logger.info("[Misc help()] adding "+str(entry)+" to page "+str(page)+" of the descriptionToEmbed")					
+						descriptionToEmbed[page]+="*"+entry['name']+"* - "+entry['description']+"\n\n"
+						x+=1
+						if x == numberOfCommandsPerPage:
+							descriptionToEmbed.append("")
+							page+=1
+							x = 0				
 			else:
 				logger.info("[Misc help()] "+str(entry)+" has a wierd access level of "+str(entry['access'])+"....not sure how to handle it so not adding it to the descriptionToEmbed")
 		logger.info("[Misc help()] transfer successful")

--- a/commands_to_load/help.json
+++ b/commands_to_load/help.json
@@ -11,8 +11,7 @@
 		{ "access": "role", "role" : "public", "name": ".whois <arg>", "description": "returns everyone who has role <arg>" },
 		{ "access": "role", "role" : "public", "name": ".roles", "description": "will display all the self-assignable roles that exist"},
 		{ "access": "role", "role" : "public", "name": ".Roles", "description": "will display all the Mod/Exec/XP Assigned roles that exist"},
-		{ "access": "role", "role" : "Minions", "name": ".purgeroles", "description": "deletes all empty self-assignable roles"},
-		{ "access": "channel", "channel" : "manage_roles", "name": ".purgeroles", "description": "deletes all empty self-assignable roles"},
+		{ "access": "permissions", "permissions" : [ "manage_roles", "administrator"] , "name": ".purgeroles", "description": "deletes all empty self-assignable roles"},
 
 		{ "access": "role", "role" : "Bot_manager", "name": "Class: Misc"},
 		{ "access": "role", "role" : "public", "name": ".help", "description": "shows this page" },

--- a/helper_files/Paginate.py
+++ b/helper_files/Paginate.py
@@ -3,7 +3,7 @@ import discord
 import asyncio
 import logging
 import helper_files.settings as settings
-from helper_files.embed import embed
+from helper_files.embed import embed as imported_embed
 
 logger = logging.getLogger('wall_e')
 
@@ -19,9 +19,11 @@ async def paginateEmbed(bot, ctx, descriptionToEmbed, title=" "):
 		logger.info("[Paginate paginateEmbed()] loading page " + str(currentPage))
 		logger.info("[Paginate paginateEmbed()] loading roles " + str(descriptionToEmbed[currentPage]))
 
-		embedObj=None
-		embedObj = embed(title=title, author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, description=descriptionToEmbed[currentPage], footer='{}/{}'.format(str(currentPage + 1), str(numOfPages)))
-		logger.info("[Paginate paginateEmbed()] embed succesfully created and populated for page " + str(currentPage))
+		embedObj = await imported_embed(ctx,title=title, author=settings.BOT_NAME, avatar=settings.BOT_AVATAR, description=descriptionToEmbed[currentPage], footer='{}/{}'.format(str(currentPage + 1), str(numOfPages)))
+		if embedObj is not None:
+			logger.info("[Paginate paginateEmbed()] embed succesfully created and populated for page " + str(currentPage))
+		else:
+			return
 
 		# determining which reactions are needed
 		if numOfPages == 1:

--- a/helper_files/listOfRoles.py
+++ b/helper_files/listOfRoles.py
@@ -1,63 +1,68 @@
 #list of possible roles to check can be pulled from here https://discordpy.readthedocs.io/en/rewrite/api.html#discord.Permissions
 
-async def getListOfUserPerms(ctx):
+async def getListOfUserPerms(ctx, userID=False):
+
+	if userID is not False:
+		userPermToCheck=ctx.guild.get_member(id)
+	else:
+		userPermToCheck = ctx.author
 	roles=[]
-	if ctx.author.guild_permissions.create_instant_invite:
+	if userPermToCheck.guild_permissions.create_instant_invite:
 		roles.append('create_instant_invite')
-	if ctx.author.guild_permissions.kick_members:
+	if userPermToCheck.guild_permissions.kick_members:
 		roles.append('kick_members')
-	if ctx.author.guild_permissions.ban_members:
+	if userPermToCheck.guild_permissions.ban_members:
 		roles.append('ban_members')
-	if ctx.author.guild_permissions.administrator:
+	if userPermToCheck.guild_permissions.administrator:
 		roles.append('administrator')
-	if ctx.author.guild_permissions.manage_channels:
+	if userPermToCheck.guild_permissions.manage_channels:
 		roles.append('manage_channels')
-	if ctx.author.guild_permissions.manage_guild:
+	if userPermToCheck.guild_permissions.manage_guild:
 		roles.append('manage_guild')
-	if ctx.author.guild_permissions.add_reactions:
+	if userPermToCheck.guild_permissions.add_reactions:
 		roles.append('add_reactions')
-	if ctx.author.guild_permissions.view_audit_log:
+	if userPermToCheck.guild_permissions.view_audit_log:
 		roles.append('view_audit_log')
-	if ctx.author.guild_permissions.priority_speaker:
+	if userPermToCheck.guild_permissions.priority_speaker:
 		roles.append('priority_speaker')
-	if ctx.author.guild_permissions.read_messages:
+	if userPermToCheck.guild_permissions.read_messages:
 		roles.append('read_messages')
-	if ctx.author.guild_permissions.send_messages:
+	if userPermToCheck.guild_permissions.send_messages:
 		roles.append('send_messages')
-	if ctx.author.guild_permissions.send_tts_messages:
+	if userPermToCheck.guild_permissions.send_tts_messages:
 		roles.append('send_tts_messages')
-	if ctx.author.guild_permissions.manage_messages:
+	if userPermToCheck.guild_permissions.manage_messages:
 		roles.append('manage_messages')
-	if ctx.author.guild_permissions.embed_links:
+	if userPermToCheck.guild_permissions.embed_links:
 		roles.append('embed_links')
-	if ctx.author.guild_permissions.attach_files:
+	if userPermToCheck.guild_permissions.attach_files:
 		roles.append('attach_files')
-	if ctx.author.guild_permissions.read_message_history:
+	if userPermToCheck.guild_permissions.read_message_history:
 		roles.append('read_message_history')
-	if ctx.author.guild_permissions.mention_everyone:
+	if userPermToCheck.guild_permissions.mention_everyone:
 		roles.append('mention_everyone')
-	if ctx.author.guild_permissions.external_emojis:
+	if userPermToCheck.guild_permissions.external_emojis:
 		roles.append('external_emojis')
-	if ctx.author.guild_permissions.connect:
+	if userPermToCheck.guild_permissions.connect:
 		roles.append('connect')
-	if ctx.author.guild_permissions.speak:
+	if userPermToCheck.guild_permissions.speak:
 		roles.append('speak')
-	if ctx.author.guild_permissions.mute_members:
+	if userPermToCheck.guild_permissions.mute_members:
 		roles.append('mute_members')
-	if ctx.author.guild_permissions.deafen_members:
+	if userPermToCheck.guild_permissions.deafen_members:
 		roles.append('deafen_members')
-	if ctx.author.guild_permissions.move_members:
+	if userPermToCheck.guild_permissions.move_members:
 		roles.append('move_members')
-	if ctx.author.guild_permissions.use_voice_activation:
+	if userPermToCheck.guild_permissions.use_voice_activation:
 		roles.append('use_voice_activation')
-	if ctx.author.guild_permissions.change_nickname:
+	if userPermToCheck.guild_permissions.change_nickname:
 		roles.append('change_nickname')
-	if ctx.author.guild_permissions.manage_nicknames:
+	if userPermToCheck.guild_permissions.manage_nicknames:
 		roles.append('manage_nicknames')
-	if ctx.author.guild_permissions.manage_roles:
+	if userPermToCheck.guild_permissions.manage_roles:
 		roles.append('manage_roles')
-	if ctx.author.guild_permissions.manage_webhooks:
+	if userPermToCheck.guild_permissions.manage_webhooks:
 		roles.append('manage_webhooks')
-	if ctx.author.guild_permissions.manage_emojis:
+	if userPermToCheck.guild_permissions.manage_emojis:
 		roles.append('manage_emojis')
 	return roles

--- a/helper_files/listOfRoles.py
+++ b/helper_files/listOfRoles.py
@@ -1,0 +1,63 @@
+#list of possible roles to check can be pulled from here https://discordpy.readthedocs.io/en/rewrite/api.html#discord.Permissions
+
+async def getListOfUserPerms(ctx):
+	roles=[]
+	if ctx.author.guild_permissions.create_instant_invite:
+		roles.append('create_instant_invite')
+	if ctx.author.guild_permissions.kick_members:
+		roles.append('kick_members')
+	if ctx.author.guild_permissions.ban_members:
+		roles.append('ban_members')
+	if ctx.author.guild_permissions.administrator:
+		roles.append('administrator')
+	if ctx.author.guild_permissions.manage_channels:
+		roles.append('manage_channels')
+	if ctx.author.guild_permissions.manage_guild:
+		roles.append('manage_guild')
+	if ctx.author.guild_permissions.add_reactions:
+		roles.append('add_reactions')
+	if ctx.author.guild_permissions.view_audit_log:
+		roles.append('view_audit_log')
+	if ctx.author.guild_permissions.priority_speaker:
+		roles.append('priority_speaker')
+	if ctx.author.guild_permissions.read_messages:
+		roles.append('read_messages')
+	if ctx.author.guild_permissions.send_messages:
+		roles.append('send_messages')
+	if ctx.author.guild_permissions.send_tts_messages:
+		roles.append('send_tts_messages')
+	if ctx.author.guild_permissions.manage_messages:
+		roles.append('manage_messages')
+	if ctx.author.guild_permissions.embed_links:
+		roles.append('embed_links')
+	if ctx.author.guild_permissions.attach_files:
+		roles.append('attach_files')
+	if ctx.author.guild_permissions.read_message_history:
+		roles.append('read_message_history')
+	if ctx.author.guild_permissions.mention_everyone:
+		roles.append('mention_everyone')
+	if ctx.author.guild_permissions.external_emojis:
+		roles.append('external_emojis')
+	if ctx.author.guild_permissions.connect:
+		roles.append('connect')
+	if ctx.author.guild_permissions.speak:
+		roles.append('speak')
+	if ctx.author.guild_permissions.mute_members:
+		roles.append('mute_members')
+	if ctx.author.guild_permissions.deafen_members:
+		roles.append('deafen_members')
+	if ctx.author.guild_permissions.move_members:
+		roles.append('move_members')
+	if ctx.author.guild_permissions.use_voice_activation:
+		roles.append('use_voice_activation')
+	if ctx.author.guild_permissions.change_nickname:
+		roles.append('change_nickname')
+	if ctx.author.guild_permissions.manage_nicknames:
+		roles.append('manage_nicknames')
+	if ctx.author.guild_permissions.manage_roles:
+		roles.append('manage_roles')
+	if ctx.author.guild_permissions.manage_webhooks:
+		roles.append('manage_webhooks')
+	if ctx.author.guild_permissions.manage_emojis:
+		roles.append('manage_emojis')
+	return roles

--- a/main.py
+++ b/main.py
@@ -264,6 +264,7 @@ async def on_command(ctx):
 			conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
 			curs = conn.cursor()
 			index=0
+			argument=''
 			for arg in ctx.args:
 				if index > 1:
 					argument += arg+' '


### PR DESCRIPTION
Fixed a couple things

- added a useful helper file that can be used to return the list of permissions that a user has. help can use this alot as the need to distinguish which user is allowed to access a command based on their roles is becoming necessary due to `.purgeroles`

- modifying how the help command decides who gets to see the `.purgeroles` command now that is access type is changed from "channel" to "permission"