### PR TITLE
Fixing another ban intercept bug + added function to remove listeners in ban cog on unload

### DIFF
--- a/wall_e/src/resources/cogs/ban.py
+++ b/wall_e/src/resources/cogs/ban.py
@@ -100,6 +100,9 @@ class Ban(commands.Cog):
 
         # need to read the audit log to grab mod, date, and reason
         logger.info(f"[Ban intercept()] guild ban detected and intercepted for user='{member}'")
+        logger.info(f"[Ban intercept()] waiting 1 second to ensure ban log is created")
+        await asyncio.sleep(1)
+
         try:
             audit_ban = await guild.audit_logs(action=discord.AuditLogAction.ban, oldest_first=False).flatten()
         except Exception as e:
@@ -107,11 +110,14 @@ class Ban(commands.Cog):
             await self.mod_channel.send(f"Encountered following error while intercepting a ban: {e}\n" +
                                         "**Most likely need view audit log perms.**")
             return
+
         audit_ban = next((audit_ban for audit_ban in audit_ban if audit_ban.target.id == member.id), None)
         if audit_ban is None:
             logger.info("[Ban intercept()] Problem occurred with ban intercept, aborting and notifying mod channel")
             await self.mod_channel.send(f"Ban for {member.name} has not been added to walle due to error"
-                                        "Please use `.convertbans` then `.purgebans` to add to walle system.")
+                                        "Please use `.convertbans` then `.purgebans` to add to walle system.\n"
+                                        "Don't use `.purgebans` if you have a user ip banned, manually unban from "
+                                        "server settings instead.")
             return
 
         logger.info(f"[Ban intercept()] audit log data retrieved for intercepted ban: {audit_ban}")

--- a/wall_e/src/resources/cogs/ban.py
+++ b/wall_e/src/resources/cogs/ban.py
@@ -101,6 +101,7 @@ class Ban(commands.Cog):
         # need to read the audit log to grab mod, date, and reason
         logger.info(f"[Ban intercept()] guild ban detected and intercepted for user='{member}'")
         logger.info("[Ban intercept()] waiting 1 second to ensure ban log is created")
+        # sleep is needed so discord has time to create the audit log
         await asyncio.sleep(1)
 
         try:
@@ -115,9 +116,7 @@ class Ban(commands.Cog):
         if audit_ban is None:
             logger.info("[Ban intercept()] Problem occurred with ban intercept, aborting and notifying mod channel")
             await self.mod_channel.send(f"Ban for {member.name} has not been added to walle due to error"
-                                        "Please use `.convertbans` then `.purgebans` to add to walle system.\n"
-                                        "Don't use `.purgebans` if you have a user ip banned, manually unban from "
-                                        "server settings instead.")
+                                        "Please use `.convertbans` then `.purgebans` to add to walle system.")
             return
 
         logger.info(f"[Ban intercept()] audit log data retrieved for intercepted ban: {audit_ban}")

--- a/wall_e/src/resources/cogs/ban.py
+++ b/wall_e/src/resources/cogs/ban.py
@@ -448,3 +448,9 @@ class Ban(commands.Cog):
             await self.bot.guilds[0].unban(ban.user)
 
         await ctx.send(f"**GUILD BAN LIST PURGED**\nTotal # of users unbanned: {len(bans)}")
+
+    def cog_unload(self):
+        logger.info('[Ban cog_load()] Removing listeners for ban cog: on_ready, on_member_join, on_member_ban')
+        self.bot.remove_listener(self.load, 'on_ready')
+        self.bot.remove_listener(self.watchdog, 'on_member_join')
+        self.bot.remove_listener(self.intercept, 'on_member_ban')

--- a/wall_e/src/resources/cogs/ban.py
+++ b/wall_e/src/resources/cogs/ban.py
@@ -100,7 +100,7 @@ class Ban(commands.Cog):
 
         # need to read the audit log to grab mod, date, and reason
         logger.info(f"[Ban intercept()] guild ban detected and intercepted for user='{member}'")
-        logger.info(f"[Ban intercept()] waiting 1 second to ensure ban log is created")
+        logger.info("[Ban intercept()] waiting 1 second to ensure ban log is created")
         await asyncio.sleep(1)
 
         try:


### PR DESCRIPTION
Same function still wasn't working finally found the cause. `on_member_ban` would trigger the intercept function and it would immediately retrieve the audit logs, but the logs isn't created at that point. Added an `asyncio.sleep(1)` which fixed the problem. I tested this with a bunch on my server to make sure 1 second was enough time. 

I added the `cog_unload` function so that if the cog is unloaded it'll remove the `@commands.Cog.listener()`'s as well. By default when a cog is unload it's listeners are still active, this'll take care of removing them if the cog is unloaded. 

## Description


## PR Checklist

These are the things you need to ensure are covered in your PR, otherwise the CODEOWNERS will not approve your PR, not matter how much you ping them to do so on the Discord  
  
 1. The description in the PR is a fair representation of what the PR is about.
 1. The PR is fixing one thing and one thing only.
 1. Logging. if you have N variables initialzed/used in your function, you should print all of them out to the log using logging module at least once or have a good reason why you arent.
 1. If your PR is doing something like adding a new line or removing a new line, CODEOWNERS reserve the right to ask that you undo that change unless it was for a specific reason.
 1. If you are adding a new command....document. Document the following things on help.json and the README.md
    1. The purpose of the command
    1. If the argument is called with any arguments.
       1. If it is called with any arguments, please either provide a good enough explanation of the arg that a user can tell what it will do before using the command. adding an example of how to call it with the args is not necessary but good practice.
 1. If you are making a new Class of commands, add the class to bot.json following the convention already there.
 1. Evidence of Testing. This one needs to be completed after the PR is opened. At that point, you will go on the channel on the CSSS Wall-E Test Server that was automatically created when the PR was opened and then test the [following functionality](https://github.com/CSSS/wall_e/blob/master/documentation/Working_on_Bot/Test_Cases.md). Once you had done so, you can leave a comment on the PR stating that you had done the necessary testing.
 1. Please provide ways to test whatever you just modified on the bot in the [Test Cases section](https://github.com/CSSS/wall_e/blob/master/documentation/Working_on_Bot/Test_Cases.md) so that future PRs can be tested to ensure they dont break your code when merging to master
