### PR TITLE
switch cog loading logic to use load_extension

### DIFF
--- a/wall_e/cogs/custom_commands.py
+++ b/wall_e/cogs/custom_commands.py
@@ -5,7 +5,7 @@ from discord.ext import commands
 
 class CustomCommands(commands.Cog):
 
-    def __init__(self, bot, config, bot_channel_manager):
+    def __init__(self):
         pass
 
     @commands.command()
@@ -98,3 +98,7 @@ class CustomCommands(commands.Cog):
     @commands.command()
     async def thebest(self, ctx):
         await ctx.send("404: Best not found.")
+
+
+async def setup(bot):
+    await bot.add_cog(CustomCommands())

--- a/wall_e/cogs/frosh.py
+++ b/wall_e/cogs/frosh.py
@@ -2,6 +2,8 @@ import asyncio
 
 from discord.ext import commands
 
+from utilities.global_vars import bot, wall_e_config
+
 from utilities.embed import embed as em, WallEColour
 from utilities.file_uploading import start_file_uploading
 from utilities.setup_logger import Loggers
@@ -9,37 +11,34 @@ from utilities.setup_logger import Loggers
 
 class Frosh(commands.Cog):
 
-    def __init__(self, bot, config, bot_channel_manager):
+    def __init__(self):
         log_info = Loggers.get_logger(logger_name="Frosh")
         self.logger = log_info[0]
         self.debug_log_file_absolute_path = log_info[1]
         self.error_log_file_absolute_path = log_info[2]
         self.logger.info("[Frosh __init__()] initializing Frosh")
-        self.bot = bot
-        self.config = config
         self.guild = None
-        self.bot_channel_manager = bot_channel_manager
 
     @commands.Cog.listener(name="on_ready")
     async def get_guild(self):
-        self.guild = self.bot.guilds[0]
+        self.guild = bot.guilds[0]
 
     @commands.Cog.listener(name="on_ready")
     async def upload_debug_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.debug_log_file_absolute_path, "frosh_debug"
+                self.logger, self.guild, bot, wall_e_config, self.debug_log_file_absolute_path, "frosh_debug"
             )
 
     @commands.Cog.listener(name="on_ready")
     async def upload_error_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.error_log_file_absolute_path, "frosh_error"
+                self.logger, self.guild, bot, wall_e_config, self.error_log_file_absolute_path, "frosh_error"
             )
 
     @commands.command(
@@ -152,3 +151,7 @@ class Frosh(commands.Cog):
 
         self.logger.info(f'[Frosh reportwin()] winner announcement embed made with following fields: {e_obj.fields}')
         await ctx.send(embed=e_obj)
+
+
+async def setup(bot):
+    await bot.add_cog(Frosh())

--- a/wall_e/cogs/health_checks.py
+++ b/wall_e/cogs/health_checks.py
@@ -4,6 +4,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from utilities.global_vars import bot, wall_e_config
+
 from utilities.embed import embed
 from utilities.file_uploading import start_file_uploading
 from utilities.setup_logger import Loggers
@@ -11,38 +13,35 @@ from utilities.setup_logger import Loggers
 
 class HealthChecks(commands.Cog):
 
-    def __init__(self, bot, config, bot_channel_manager):
+    def __init__(self):
         log_info = Loggers.get_logger(logger_name="HealthChecks")
         self.logger = log_info[0]
         self.debug_log_file_absolute_path = log_info[1]
         self.error_log_file_absolute_path = log_info[2]
         self.logger.info("[HealthChecks __init__()] initializing HealthChecks")
-        self.bot = bot
-        self.config = config
         self.guild = None
-        self.bot_channel_manager = bot_channel_manager
 
     @commands.Cog.listener(name="on_ready")
     async def get_guild(self):
-        self.guild = self.bot.guilds[0]
+        self.guild = bot.guilds[0]
 
     @commands.Cog.listener(name="on_ready")
     async def upload_debug_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.debug_log_file_absolute_path,
+                self.logger, self.guild, bot, wall_e_config, self.debug_log_file_absolute_path,
                 "health_checks_debug"
             )
 
     @commands.Cog.listener(name="on_ready")
     async def upload_error_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.error_log_file_absolute_path,
+                self.logger, self.guild, bot, wall_e_config, self.error_log_file_absolute_path,
                 "health_checks_error"
             )
 
@@ -72,3 +71,7 @@ class HealthChecks(commands.Cog):
         )
         if e_obj is not False:
             await interaction.response.send_message(embed=e_obj)
+
+
+async def setup(bot):
+    await bot.add_cog(HealthChecks())

--- a/wall_e/cogs/here.py
+++ b/wall_e/cogs/here.py
@@ -6,43 +6,42 @@ import asyncio
 import discord
 from discord.ext import commands
 
+from utilities.global_vars import bot, wall_e_config
+
 from utilities.file_uploading import start_file_uploading
 from utilities.setup_logger import Loggers
 
 
 class Here(commands.Cog):
 
-    def __init__(self, bot, config, bot_channel_manager):
+    def __init__(self):
         log_info = Loggers.get_logger(logger_name="Here")
         self.logger = log_info[0]
         self.debug_log_file_absolute_path = log_info[1]
         self.error_log_file_absolute_path = log_info[2]
         self.logger.info("[Here __init__()] initializing Here")
-        self.bot = bot
-        self.config = config
         self.guild = None
-        self.bot_channel_manager = bot_channel_manager
 
     @commands.Cog.listener(name="on_ready")
     async def get_guild(self):
-        self.guild = self.bot.guilds[0]
+        self.guild = bot.guilds[0]
 
     @commands.Cog.listener(name="on_ready")
     async def upload_debug_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.debug_log_file_absolute_path, "here_debug"
+                self.logger, self.guild, bot, wall_e_config, self.debug_log_file_absolute_path, "here_debug"
             )
 
     @commands.Cog.listener(name="on_ready")
     async def upload_error_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.error_log_file_absolute_path, "here_error"
+                self.logger, self.guild, bot, wall_e_config, self.error_log_file_absolute_path, "here_error"
             )
 
     def build_embed(self, members, channel):
@@ -116,3 +115,7 @@ class Here(commands.Cog):
         embed = self.build_embed(members, channel)
 
         await ctx.send(embed=embed, delete_after=300)
+
+
+async def setup(bot):
+    await bot.add_cog(Here())

--- a/wall_e/cogs/misc.py
+++ b/wall_e/cogs/misc.py
@@ -10,6 +10,8 @@ from discord import app_commands
 from discord.ext import commands
 from matplotlib import pyplot as plt
 
+from utilities.global_vars import bot, wall_e_config
+
 from utilities.embed import embed, WallEColour
 from utilities.file_uploading import start_file_uploading
 from utilities.setup_logger import Loggers
@@ -30,39 +32,36 @@ def render_latex(formula, fontsize=12, dpi=300, format_='svg'):
 
 class Misc(commands.Cog):
 
-    def __init__(self, bot, config, bot_channel_manager):
+    def __init__(self):
         log_info = Loggers.get_logger(logger_name="Misc")
         self.logger = log_info[0]
         self.debug_log_file_absolute_path = log_info[1]
         self.error_log_file_absolute_path = log_info[2]
         self.logger.info("[Misc __init__()] initializing Misc")
-        self.bot = bot
         self.session = aiohttp.ClientSession(loop=bot.loop)
-        self.config = config
         self.guild = None
-        self.bot_channel_manager = bot_channel_manager
-        self.wolframClient = wolframalpha.Client(self.config.get_config_value('basic_config', 'WOLFRAM_API_TOKEN'))
+        self.wolframClient = wolframalpha.Client(wall_e_config.get_config_value('basic_config', 'WOLFRAM_API_TOKEN'))
 
     @commands.Cog.listener(name="on_ready")
     async def get_guild(self):
-        self.guild = self.bot.guilds[0]
+        self.guild = bot.guilds[0]
 
     @commands.Cog.listener(name="on_ready")
     async def upload_debug_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.debug_log_file_absolute_path, "misc_debug"
+                self.logger, self.guild, bot, wall_e_config, self.debug_log_file_absolute_path, "misc_debug"
             )
 
     @commands.Cog.listener(name="on_ready")
     async def upload_error_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.error_log_file_absolute_path, "misc_error"
+                self.logger, self.guild, bot, wall_e_config, self.error_log_file_absolute_path, "misc_error"
             )
 
     @commands.command(
@@ -365,3 +364,7 @@ class Misc(commands.Cog):
     async def cog_unload(self) -> None:
         await self.session.close()
         await super().cog_unload()
+
+
+async def setup(bot):
+    await bot.add_cog(Misc())

--- a/wall_e/cogs/mod.py
+++ b/wall_e/cogs/mod.py
@@ -3,6 +3,8 @@ import asyncio
 import discord
 from discord.ext import commands
 
+from utilities.global_vars import bot, wall_e_config
+
 from utilities.embed import embed
 from utilities.file_uploading import start_file_uploading
 from utilities.setup_logger import Loggers
@@ -10,37 +12,34 @@ from utilities.setup_logger import Loggers
 
 class Mod(commands.Cog):
 
-    def __init__(self, bot, config, bot_channel_manager):
+    def __init__(self):
         log_info = Loggers.get_logger(logger_name="Mod")
         self.logger = log_info[0]
         self.debug_log_file_absolute_path = log_info[1]
         self.error_log_file_absolute_path = log_info[2]
         self.logger.info("[Mod __init__()] initializing Mod")
-        self.bot = bot
-        self.config = config
         self.guild = None
-        self.bot_channel_manager = bot_channel_manager
 
     @commands.Cog.listener(name="on_ready")
     async def get_guild(self):
-        self.guild = self.bot.guilds[0]
+        self.guild = bot.guilds[0]
 
     @commands.Cog.listener(name="on_ready")
     async def upload_debug_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.debug_log_file_absolute_path, "mod_debug"
+                self.logger, self.guild, bot, wall_e_config, self.debug_log_file_absolute_path, "mod_debug"
             )
 
     @commands.Cog.listener(name="on_ready")
     async def upload_error_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.error_log_file_absolute_path, "mod_error"
+                self.logger, self.guild, bot, wall_e_config, self.error_log_file_absolute_path, "mod_error"
             )
 
     @commands.command(
@@ -156,3 +155,7 @@ class Mod(commands.Cog):
         )
         if e_obj is not False:
             await ctx.send(embed=e_obj)
+
+
+async def setup(bot):
+    await bot.add_cog(Mod())

--- a/wall_e/cogs/role_commands.py
+++ b/wall_e/cogs/role_commands.py
@@ -5,6 +5,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from utilities.global_vars import bot, wall_e_config
+
 from utilities.embed import embed, WallEColour
 from utilities.file_uploading import start_file_uploading
 from utilities.paginate import paginate_embed
@@ -19,40 +21,37 @@ def user_can_manage_roles(ctx: discord.Interaction) -> bool:
 
 class RoleCommands(commands.Cog):
 
-    def __init__(self, bot, config, bot_channel_manager):
+    def __init__(self):
         log_info = Loggers.get_logger(logger_name="RoleCommands")
         self.logger = log_info[0]
         self.debug_log_file_absolute_path = log_info[1]
         self.error_log_file_absolute_path = log_info[2]
         self.logger.info("[RoleCommands __init__()] initializing RoleCommands")
-        self.bot = bot
-        self.config = config
         self.guild = None
         self.bot_channel = None
         self.exec_role_colour = [3447003, 6533347]
-        self.bot_channel_manager = bot_channel_manager
 
     @commands.Cog.listener(name="on_ready")
     async def get_guild(self):
-        self.guild = self.bot.guilds[0]
+        self.guild = bot.guilds[0]
 
     @commands.Cog.listener(name="on_ready")
     async def upload_debug_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.debug_log_file_absolute_path,
+                self.logger, self.guild, bot, wall_e_config, self.debug_log_file_absolute_path,
                 "role_commands_debug"
             )
 
     @commands.Cog.listener(name="on_ready")
     async def upload_error_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.error_log_file_absolute_path,
+                self.logger, self.guild, bot, wall_e_config, self.error_log_file_absolute_path,
                 "role_commands_error"
             )
 
@@ -60,8 +59,8 @@ class RoleCommands(commands.Cog):
     async def get_bot_general_channel(self):
         while self.guild is None:
             await asyncio.sleep(2)
-        reminder_chan_id = await self.bot_channel_manager.create_or_get_channel_id(
-            self.logger, self.guild, self.config.get_config_value('basic_config', 'ENVIRONMENT'),
+        reminder_chan_id = await bot.bot_channel_manager.create_or_get_channel_id(
+            self.logger, self.guild, wall_e_config.get_config_value('basic_config', 'ENVIRONMENT'),
             "role_commands"
         )
         self.bot_channel = discord.utils.get(
@@ -331,7 +330,7 @@ class RoleCommands(commands.Cog):
 
             title = f"Members belonging to role: `{role}`"
             await paginate_embed(
-                self.logger, self.bot, member_string, title=title, interaction=interaction
+                self.logger, bot, member_string, title=title, interaction=interaction
             )
 
     @app_commands.command(
@@ -373,7 +372,7 @@ class RoleCommands(commands.Cog):
                     x = 0
             self.logger.info("[RoleCommands roles()] transfer successful")
             await paginate_embed(
-                self.logger, self.bot, description_to_embed, "Self-Assignable Roles", interaction=interaction
+                self.logger, bot, description_to_embed, "Self-Assignable Roles", interaction=interaction
             )
 
     @app_commands.command(
@@ -414,7 +413,7 @@ class RoleCommands(commands.Cog):
                     x = 0
             self.logger.info("[RoleCommands Roles()] transfer successful")
             await paginate_embed(
-                self.logger, self.bot, description_to_embed, "Mod/Exec/XP Assigned Roles", interaction=interaction
+                self.logger, bot, description_to_embed, "Mod/Exec/XP Assigned Roles", interaction=interaction
             )
 
     @app_commands.command(name="purgeroles", description="deletes all empty self-assignable roles")
@@ -563,3 +562,7 @@ class RoleCommands(commands.Cog):
                 "[RoleCommands send_error_message_to_user_for_paginated_commands()] "
                 f"embed sent to member {interaction.user}"
             )
+
+
+async def setup(bot):
+    await bot.add_cog(RoleCommands())

--- a/wall_e/cogs/sfu.py
+++ b/wall_e/cogs/sfu.py
@@ -7,44 +7,43 @@ import time
 import aiohttp
 from discord.ext import commands
 
+from utilities.global_vars import bot, wall_e_config
+
 from utilities.embed import embed, WallEColour
 from utilities.file_uploading import start_file_uploading
 from utilities.setup_logger import Loggers
 
 
 class SFU(commands.Cog):
-    def __init__(self, bot, config, bot_channel_manager):
+    def __init__(self):
         log_info = Loggers.get_logger(logger_name="SFU")
         self.logger = log_info[0]
         self.debug_log_file_absolute_path = log_info[1]
         self.error_log_file_absolute_path = log_info[2]
         self.logger.info("[SFU __init__()] initializing SFU")
-        self.bot = bot
         self.req = aiohttp.ClientSession(loop=bot.loop)
-        self.config = config
         self.guild = None
-        self.bot_channel_manager = bot_channel_manager
 
     @commands.Cog.listener(name="on_ready")
     async def get_guild(self):
-        self.guild = self.bot.guilds[0]
+        self.guild = bot.guilds[0]
 
     @commands.Cog.listener(name="on_ready")
     async def upload_debug_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.debug_log_file_absolute_path, "sfu_debug"
+                self.logger, self.guild, bot, wall_e_config, self.debug_log_file_absolute_path, "sfu_debug"
             )
 
     @commands.Cog.listener(name="on_ready")
     async def upload_error_logs(self):
-        if self.config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
+        if wall_e_config.get_config_value('basic_config', 'ENVIRONMENT') != 'TEST':
             while self.guild is None:
                 await asyncio.sleep(2)
             await start_file_uploading(
-                self.logger, self.guild, self.bot, self.config, self.error_log_file_absolute_path, "sfu_error"
+                self.logger, self.guild, bot, wall_e_config, self.error_log_file_absolute_path, "sfu_error"
             )
 
     @commands.command(
@@ -509,3 +508,7 @@ class SFU(commands.Cog):
     async def cog_unload(self) -> None:
         await self.req.close()
         await super().cog_unload()
+
+
+async def setup(bot):
+    await bot.add_cog(SFU())

--- a/wall_e/overriden_coroutines/error_handlers.py
+++ b/wall_e/overriden_coroutines/error_handlers.py
@@ -4,8 +4,6 @@ import re
 import discord
 from discord.ext import commands
 
-from cogs.manage_test_guild import ManageTestGuild
-
 
 from utilities.embed import WallEColour, embed
 from utilities.setup_logger import print_wall_e_exception
@@ -19,6 +17,7 @@ async def report_text_command_error(ctx, error):
     :return:
     """
     from utilities.global_vars import logger
+    from cogs.manage_test_guild import ManageTestGuild
     correct_channel = ManageTestGuild.check_text_command_test_environment(ctx)
     if correct_channel:
         if isinstance(error, commands.errors.ArgumentParsingError):

--- a/wall_e/utilities/bot_channel_manager.py
+++ b/wall_e/utilities/bot_channel_manager.py
@@ -195,6 +195,7 @@ class BotChannelManager:
             await asyncio.sleep(20)  # this is just here so that the above log line
             # gets a chance to get printed to discord
             exit(1)
+
         logger.info(
             f"[BotChannelManager create_or_get_channel_id_for_service()] the channel {service} for "
             f"in {environment} acquired."

--- a/wall_e/utilities/global_vars.py
+++ b/wall_e/utilities/global_vars.py
@@ -3,7 +3,6 @@ import os
 import django
 from django.core.wsgi import get_wsgi_application
 
-
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_settings")
 django.setup()
 
@@ -34,7 +33,6 @@ incident_report_log_info = Loggers.get_logger(logger_name="incident_report")
 
 incident_report_logger = incident_report_log_info[0]
 incident_report_debug_log_file_absolute_path = incident_report_log_info[1]
-incident_report_error_log_file_absolute_path = incident_report_log_info[2]
 
 from utilities.wall_e_bot import WalleBot # noqa E402
 


### PR DESCRIPTION
## Description

Changing the logic for how a cog is loaded to it uses `load_extension` instead of `add_cog`. This is done because now wall_e does not have to be restarted for a cog's changes to be loaded to discord. `load_extension` loads the latest code in the file, not whatever code was in the file when the bot first connected to the gateway.

This was also done in an attempt to make the bot more amenable to running slash commands in the TEST guild but if a cog is loaded to wall_e after the on_ready signal has already been received, any on_ready functions in the cog that is loaded will not be run, which is a pre-req for almost all the cogs

However, the first outlined reason for the logic change is good enough [as it makes dev work easier] so still sticking with the change despite the TEST guild issues.

## PR Checklist

> Make sure to account for all the items in the [PR checklist](https://github.com/CSSS/wall_e/wiki/4.-PR-Checklist)
