### PR TITLE
making sure the formula is taken in raw form by matplotlib

### DIFF
--- a/wall_e/cogs/misc.py
+++ b/wall_e/cogs/misc.py
@@ -19,7 +19,7 @@ def render_latex(formula, fontsize=12, dpi=300, format_='svg'):
     """Renders LaTeX formula into image.
     """
     fig = plt.figure(figsize=(0.01, 0.01))
-    fig.text(0, 0, f'${formula}$', fontsize=fontsize, color='white')
+    fig.text(0, 0, fr'${formula}$', fontsize=fontsize, color='white')
     buffer_ = BytesIO()
     fig.savefig(
         buffer_, dpi=dpi, transparent=True, format=format_, bbox_inches='tight', pad_inches=0.0, facecolor='black'


### PR DESCRIPTION
## Description

Attempting to fix this error
```
2023-10-13 15:18:49 = ERROR = Misc = Traceback (most recent call last):
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/mathtext.py", line 2618, in parse
.    result = self._expression.parseString(s)
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/pyparsing/util.py", line 256, in _inner
.    return fn(self, *args, **kwargs)
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/pyparsing/core.py", line 1197, in parse_string
.    raise exc.with_traceback(None)
2023-10-13 15:18:49 = ERROR = Misc = pyparsing.exceptions.ParseFatalException: Expected main  (at char 0), (line:1, col:1)
2023-10-13 15:18:49 = ERROR = Misc =
The above exception was the direct cause of the following exception:
2023-10-13 15:18:49 = ERROR = Misc = Traceback (most recent call last):
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/discord/app_commands/commands.py", line 827, in _do_call
.    return await self._callback(self.binding, interaction, **params)  # type: ignore
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/src/app/cogs/misc.py", line 359, in tex
.    image_bytes = renderlatex(formula, fontsize=10, dpi=200, format='png')
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/src/app/cogs/misc.py", line 24, in render_latex
.    fig.savefig(
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/figure.py", line 2311, in savefig
.    self.canvas.print_figure(fname, **kwargs)
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/backend_bases.py", line 2193, in print_figure
.    self.figure.draw(renderer)
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/artist.py", line 41, in draw_wrapper
.    return draw(artist, renderer, *args, **kwargs)
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/figure.py", line 1863, in draw
.    mimage._draw_list_compositing_images(
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/image.py", line 132, in _draw_list_compositing_images
.    a.draw(renderer)
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/artist.py", line 41, in draw_wrapper
.    return draw(artist, renderer, *args, **kwargs)
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/text.py", line 679, in draw
.    bbox, info, descent = textobj._get_layout(renderer)
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/text.py", line 293, in _get_layout
.    w, h, d = renderer.get_text_width_height_descent(
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/backends/backend_agg.py", line 233, in get_text_width_height_descent
.    self.mathtext_parser.parse(s, self.dpi, prop)
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/mathtext.py", line 3341, in parse
.    return self._parse_cached(
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/mathtext.py", line 3365, in _parse_cached
.    box = self._parser.parse(s, font_output, fontsize, dpi)
2023-10-13 15:18:49 = ERROR = Misc =   File "/usr/local/lib/python3.8/site-packages/matplotlib/mathtext.py", line 2620, in parse
.    raise ValueError("\n".join(["",
2023-10-13 15:18:49 = ERROR = Misc = ValueError:
^
Expected main  (at char 0), (line:1, col:1)
```

## PR Checklist

> Make sure to account for all the items in the [PR checklist](https://github.com/CSSS/wall_e/wiki/4.-PR-Checklist)
