### PR TITLE
room key fix

### DIFF
--- a/wall_e/extensions/sfu.py
+++ b/wall_e/extensions/sfu.py
@@ -427,7 +427,7 @@ class SFU(commands.Cog):
             sec_code = f'[{x["sectionCode"]}]'
             days = x['days']
             tme = f'{x["startTime"]}-{x["endTime"]}'
-            room = f'{x["buildingCode"]} {x["roomNumber"]}'
+            room = f'{x.get("buildingCode", "Room TBD")} {x.get("roomNumber", "")}'
             campus = x['campus']
             crs = f'{crs}{sec_code} {days} {tme}, {room}, {campus}\n'
 


### PR DESCRIPTION
## Description

error in outline caused when room isn't assigned to a course so the key doesn't exist. 

## PR Checklist

> Make sure to account for all the items in the [PR checklist](https://github.com/CSSS/wall_e/wiki/4.-PR-Checklist)
