### PR TITLE
Fixing user data scraper

### DIFF
--- a/CI/validate_and_deploy/2_deploy/server_scripts/Dockerfile.wall_e_base
+++ b/CI/validate_and_deploy/2_deploy/server_scripts/Dockerfile.wall_e_base
@@ -12,4 +12,4 @@ COPY wall_e/requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-RUN pip install wall-e-models==0.17
+RUN pip install wall-e-models==0.21


### PR DESCRIPTION
## Description


adding 2 asynchronous background tasks that will fetch the latest user data for both lurkers and active users


- `process_leveling_profile_data_for_active_users` will run every 2 seconds to try and recieve the latest detected changes from https://github.com/CSSS/wall_e_member_update_listener and update the database with those changes
- `process_leveling_profile_data_for_lurkers` will run at 4 am everyday pacific time that intends to update the profile for X/28<sup>1</sup> users to capture the updates that happened for both lurkers as well as any updates that were missed in `process_leveling_profile_data_for_active_users`; this can happen if between `fetch_member/fetch_user` and the save code-line in `update_leveling_profile_info`, the https://github.com/CSSS/wall_e_member_update_listener received another update from the user where they reverted any changes they made a second before

<sup>1</sup> where X is the number of members that wall_e knows about that were ever in the guild

## PR Checklist

> Make sure to account for all the items in the [PR checklist](https://github.com/CSSS/wall_e/wiki/4.-PR-Checklist)
