### PR TITLE
Fix error message reporting for no dm users

### DIFF
--- a/wall_e/extensions/role_commands.py
+++ b/wall_e/extensions/role_commands.py
@@ -180,9 +180,7 @@ class RoleCommands(commands.Cog):
                 description="Roles Cache Updated"
             )
             if e_obj:
-                await self.send_message_to_user_or_bot_channel(
-                    e_obj, interaction, send_func=interaction.followup.send
-                )
+                await self.send_message_to_user_or_bot_channel(e_obj, interaction)
         else:
             e_obj = await embed(
                 self.logger,
@@ -191,9 +189,7 @@ class RoleCommands(commands.Cog):
                 description="Roles Cache Already Being Updated"
             )
             if e_obj:
-                await self.send_message_to_user_or_bot_channel(
-                    e_obj, interaction, send_func=interaction.followup.send
-                )
+                await self.send_message_to_user_or_bot_channel(e_obj, interaction)
 
     @app_commands.command(name="newrole", description="creates assignable role with the specified name")
     @app_commands.describe(new_role_name="name for assignable role to create")
@@ -214,9 +210,7 @@ class RoleCommands(commands.Cog):
                 colour=WallEColour.ERROR
             )
             if e_obj is not False:
-                await self.send_message_to_user_or_bot_channel(
-                    e_obj, interaction=interaction, send_func=interaction.followup.send
-                )
+                await self.send_message_to_user_or_bot_channel(e_obj, interaction)
                 self.logger.debug(f"[RoleCommands newrole()] {new_role_name} already exists")
             return
         role = await guild.create_role(name=new_role_name)
@@ -233,9 +227,7 @@ class RoleCommands(commands.Cog):
                 f"**`{new_role_name}`**.\nCalling `.iam {new_role_name}` will add it to you."
             )
         )
-        await self.send_message_to_user_or_bot_channel(
-            e_obj, interaction=interaction, send_func=interaction.followup.send
-        )
+        await self.send_message_to_user_or_bot_channel(e_obj, interaction)
 
     @app_commands.command(name="deleterole", description="deletes empty assignable role with the specified name")
     @app_commands.describe(empty_role="name for empty assignable role to remove")
@@ -255,9 +247,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{empty_role}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(
-                e_obj, interaction=interaction, send_func=interaction.followup.send
-            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
             return
         role = discord.utils.get(interaction.guild.roles, id=int(empty_role))
         if role is None:
@@ -269,9 +259,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{empty_role}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(
-                e_obj, interaction=interaction, send_func=interaction.followup.send
-            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
             return
         await role.delete()
         del self.lowercase_roles[int(empty_role)]
@@ -282,9 +270,7 @@ class RoleCommands(commands.Cog):
             author=interaction.client.user,
             description=f"Role **`{role}`** deleted."
         )
-        await self.send_message_to_user_or_bot_channel(
-            e_obj, interaction=interaction, send_func=interaction.followup.send
-        )
+        await self.send_message_to_user_or_bot_channel(e_obj, interaction)
 
     @app_commands.command(name="iam", description="add yourself to an assignable role")
     @app_commands.describe(role_to_assign_to_me="name for existing role to assign to yourself")
@@ -303,9 +289,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role_to_assign_to_me}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(
-                e_obj, interaction=interaction, send_func=interaction.followup.send
-            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
             return
         role = discord.utils.get(interaction.guild.roles, id=int(role_to_assign_to_me))
         if role is None:
@@ -317,9 +301,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role_to_assign_to_me}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(
-                e_obj, interaction=interaction, send_func=interaction.followup.send
-            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
             return
         user = interaction.user
         await user.add_roles(role)
@@ -342,9 +324,7 @@ class RoleCommands(commands.Cog):
                 author=interaction.client.user,
                 description=f"You have successfully been added to role **`{role}`**."
             )
-        await self.send_message_to_user_or_bot_channel(
-            e_obj, interaction=interaction, send_func=interaction.followup.send
-        )
+        await self.send_message_to_user_or_bot_channel(e_obj, interaction)
 
     @app_commands.command(name="iamn", description="remove yourself from an assignable role")
     @app_commands.describe(role_to_remove_from_me="name for existing role to remove from yourself")
@@ -365,9 +345,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role_to_remove_from_me}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(
-                e_obj, interaction=interaction, send_func=interaction.followup.send
-            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
             return
         role = discord.utils.get(interaction.guild.roles, id=int(role_to_remove_from_me))
         if role is None:
@@ -379,9 +357,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role_to_remove_from_me}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(
-                e_obj, interaction=interaction, send_func=interaction.followup.send
-            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
             return
         user = interaction.user
         await user.remove_roles(role)
@@ -395,9 +371,7 @@ class RoleCommands(commands.Cog):
         )
         if e_obj is not False:
             self.logger.debug(f"[RoleCommands iamn()] {user} has been removed from role {role}")
-        await self.send_message_to_user_or_bot_channel(
-            e_obj, interaction=interaction, send_func=interaction.followup.send
-        )
+        await self.send_message_to_user_or_bot_channel(e_obj, interaction)
         # delete role if last person
         members_of_role = role.members
         if not members_of_role:
@@ -409,9 +383,7 @@ class RoleCommands(commands.Cog):
                 author=interaction.client.user,
                 description=f"Role **`{role.name}`** deleted."
             )
-            await self.send_message_to_user_or_bot_channel(
-                e_obj, interaction=interaction, send_func=interaction.channel.send
-            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, iamn_role_deleted=True)
 
     @app_commands.command(name="whois", description="list folks in a role")
     @app_commands.describe(role="name of the existing role to return the membership of")
@@ -438,9 +410,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(
-                e_obj, interaction=interaction, send_func=interaction.followup.send
-            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
             return
         role = discord.utils.get(interaction.guild.roles, id=int(role))
         if role is None:
@@ -452,9 +422,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(
-                e_obj, interaction=interaction, send_func=interaction.followup.send
-            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
             return
         author_roles = [
             role.name for role in interaction.user.roles

--- a/wall_e/extensions/role_commands.py
+++ b/wall_e/extensions/role_commands.py
@@ -222,7 +222,7 @@ class RoleCommands(commands.Cog):
                 colour=WallEColour.ERROR
             )
             if e_obj is not False:
-                await self.send_message_to_user_or_bot_channel(e_obj, interaction)
+                await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
                 self.logger.debug(f"[RoleCommands newrole()] {new_role_name} already exists")
             return
         role = await guild.create_role(name=new_role_name)
@@ -265,7 +265,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{empty_role}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         role = discord.utils.get(interaction.guild.roles, id=int(empty_role))
         if role is None:
@@ -277,7 +277,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{empty_role}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         await role.delete()
         del self.lowercase_roles[int(empty_role)]
@@ -313,7 +313,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role_to_assign_to_me}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         role = discord.utils.get(interaction.guild.roles, id=int(role_to_assign_to_me))
         if role is None:
@@ -325,7 +325,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role_to_assign_to_me}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         user = interaction.user
         await user.add_roles(role)
@@ -375,7 +375,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role_to_remove_from_me}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         role = discord.utils.get(interaction.guild.roles, id=int(role_to_remove_from_me))
         if role is None:
@@ -387,7 +387,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role_to_remove_from_me}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         user = interaction.user
         await user.remove_roles(role)
@@ -443,7 +443,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         role = discord.utils.get(interaction.guild.roles, id=int(role))
         if role is None:
@@ -455,7 +455,7 @@ class RoleCommands(commands.Cog):
                 description=f"Invalid role **`{role}`** specified. Please select from the list.",
                 colour=WallEColour.ERROR
             )
-            await self.send_message_to_user_or_bot_channel(e_obj, interaction)
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         author_roles = [
             role.name for role in interaction.user.roles
@@ -639,7 +639,7 @@ class RoleCommands(commands.Cog):
         )
         if not user_can_delete_roles:
             embed.title = "You don't have permissions to delete roles. :("
-            await self.send_message_to_user_or_bot_channel(embed, interaction)
+            await self.send_message_to_user_or_bot_channel(embed, interaction, delete_response=True)
             return
 
         self.logger.debug(
@@ -681,41 +681,12 @@ class RoleCommands(commands.Cog):
         embed.description = description
         await self.send_message_to_user_or_bot_channel(embed, interaction)
 
-    async def send_message_to_user_or_bot_channel(self, e_obj, interaction=None, send_func=None):
-        send_func = send_func if send_func is not None else interaction.response.send_message
-        if e_obj is not False:
-            if interaction.channel.id == self.bot_channel.id:
-                self.logger.debug("[RoleCommands send_message_to_user_or_bot_channel()] sending result to"
-                                  " the bot channel ")
-                await send_func(embed=e_obj)
-            else:
-                description = (
-                    e_obj.description + f'\n\n\nPlease call the command {interaction.command.name} from the channel '
-                                        f"[#{self.bot_channel.name}](https://discord.com/channels/"
-                                        f"{interaction.guild.id}/{self.bot_channel.id}) to "
-                                        f'avoid getting this warning'
-                )
-                e_obj = await embed(
-                    self.logger,
-                    interaction=interaction,
-                    title='ATTENTION:',
-                    colour=WallEColour.ERROR,
-                    author=interaction.client.user,
-                    description=description
-                )
-                if e_obj is not False:
-                    self.logger.debug(
-                        "[RoleCommands send_message_to_user_or_bot_channel()] DMing the result to the user")
-                    try:
-                        await interaction.user.send(embed=e_obj)
-                    except discord.errors.Forbidden:
-                        await self.bot_channel.send(f'<@{interaction.user.id}>', embed=e_obj)
-
-    async def send_error_message_to_user_for_paginated_commands(self, interaction=None):
-        if interaction.user.dm_channel is None:
-            send_func = (await interaction.user.create_dm()).send
-        else:
-            send_func = interaction.user.dm_channel.send
+    async def alert_user_to_use_bot_channel_for_paginated_commands(self, interaction):
+        """
+        Invoked when a paginated role command is called from a non bot_channel channel
+        :param interaction:
+        :return:
+        """
         description = (f'Please call the command `{interaction.command.name}` from the channel '
                        f"[#{self.bot_channel.name}](https://discord.com/channels/"
                        f"{interaction.guild_id}/{self.bot_channel.id}) to be able to use this command")
@@ -728,11 +699,88 @@ class RoleCommands(commands.Cog):
             author=interaction.client.user,
         )
         if e_obj is not False:
-            await send_func(embed=e_obj)
+            try:
+                await interaction.delete_original_response()
+                send_func = await RoleCommands._obtain_dm_channel(interaction)
+                await send_func(embed=e_obj)
+            except discord.errors.Forbidden:
+                await self.send_message_to_bot_channel(interaction, e_obj)
             self.logger.debug(
-                "[RoleCommands send_error_message_to_user_for_paginated_commands()] "
+                "[RoleCommands alert_user_to_use_bot_channel_for_paginated_commands()] "
                 f"embed sent to member {interaction.user}"
             )
+
+    @staticmethod
+    async def _obtain_dm_channel(interaction):
+        return (await interaction.user.create_dm()).send \
+            if interaction.user.dm_channel is None else interaction.user.dm_channel.send
+
+    async def send_message_to_bot_channel(self, interaction, e_obj, delete_response=False):
+        msg = await self.bot_channel.send(f'<@{interaction.user.id}>', embed=e_obj)
+        if delete_response:
+            await asyncio.sleep(20)
+            await msg.delete()
+
+    async def send_message_to_user_or_bot_channel(self, e_obj, interaction, iamn_role_deleted=False,
+                                                  delete_response=False):
+        """
+        Responsible for directing the message to the invoking channel [if the channel is the bot_channel] or
+         DMing the message to the user otherwise
+        :param e_obj: the response embed to send back to the user
+        :param interaction:
+        :param iamn_role_deleted: indicator of whether the function call is from the iamn command alerting the user
+         that they let a role which has no members left, so it has been deleted. Necessary to know if this is the
+         second time this function is being called from that command and therefore the original response has
+          already been deleted
+        :param delete_response: if the response that this function sends has to be deleted, as there is no reason
+         for the error message to stick around
+        :return:
+        """
+        deferred_interaction = interaction.response.type is not None
+        if deferred_interaction:
+            channel_send_func = interaction.followup.send
+        else:
+            channel_send_func = interaction.response.send_message
+        if e_obj is not False:
+            if interaction.channel.id == self.bot_channel.id:
+                self.logger.debug("[RoleCommands send_message_to_user_or_bot_channel()] sending result to"
+                                  " the bot channel ")
+                await channel_send_func(embed=e_obj)
+                if delete_response:
+                    await asyncio.sleep(10)
+                    await interaction.delete_original_response()
+            else:
+                description = (
+                    e_obj.description + f'\n\n\nAdditionally, please call the command `{interaction.command.name}` '
+                    f'from the channel [#{self.bot_channel.name}](https://discord.com/channels/{interaction.guild.id}'
+                    f'/{self.bot_channel.id})'
+                )
+                successful_call = e_obj.colour != WallEColour.ERROR
+                if successful_call:
+                    description += " to avoid getting this warning"
+                e_obj = await embed(
+                    self.logger,
+                    interaction=interaction,
+                    title='ATTENTION:',
+                    colour=WallEColour.ERROR,
+                    author=interaction.client.user,
+                    description=description
+                )
+                if e_obj is not False:
+                    self.logger.debug(
+                        "[RoleCommands send_message_to_user_or_bot_channel()] DMing the result to the user")
+                    try:
+                        if not iamn_role_deleted:
+                            await interaction.delete_original_response()
+                        if delete_response:
+                            await channel_send_func(embed=e_obj)
+                            await asyncio.sleep(10)
+                            await interaction.delete_original_response()
+                        else:
+                            send_func = await RoleCommands._obtain_dm_channel(interaction)
+                            await send_func(embed=e_obj)
+                    except discord.errors.Forbidden:
+                        await self.send_message_to_bot_channel(interaction, e_obj, delete_response=delete_response)
 
 
 async def setup(bot):

--- a/wall_e/extensions/role_commands.py
+++ b/wall_e/extensions/role_commands.py
@@ -248,6 +248,14 @@ class RoleCommands(commands.Cog):
         self.logger.info(f"[RoleCommands deleterole()] {interaction.user} "
                          f"called deleterole with role {empty_role}.")
         if empty_role == "-1":
+            e_obj = await embed(
+                self.logger,
+                interaction=interaction,
+                author=interaction.client.user,
+                description="Invalid input detected. Please try again.",
+                colour=WallEColour.ERROR
+            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         try:
             await interaction.response.defer()
@@ -296,6 +304,14 @@ class RoleCommands(commands.Cog):
     async def iam(self, interaction: discord.Interaction, role_to_assign_to_me: str):
         self.logger.info(f"[RoleCommands iam()] {interaction.user} called iam with role {role_to_assign_to_me}")
         if role_to_assign_to_me == "-1":
+            e_obj = await embed(
+                self.logger,
+                interaction=interaction,
+                author=interaction.client.user,
+                description="Invalid input detected. Please try again.",
+                colour=WallEColour.ERROR
+            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         try:
             await interaction.response.defer()
@@ -358,6 +374,14 @@ class RoleCommands(commands.Cog):
             f"[RoleCommands iamn()] {interaction.user} called iamn with role {role_to_remove_from_me}"
         )
         if role_to_remove_from_me == "-1":
+            e_obj = await embed(
+                self.logger,
+                interaction=interaction,
+                author=interaction.client.user,
+                description="Invalid input detected. Please try again.",
+                colour=WallEColour.ERROR
+            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         try:
             await interaction.response.defer()
@@ -423,6 +447,14 @@ class RoleCommands(commands.Cog):
             f"[RoleCommands whois()] {interaction.user} called whois with role {role}"
         )
         if role == "-1":
+            e_obj = await embed(
+                self.logger,
+                interaction=interaction,
+                author=interaction.client.user,
+                description="Invalid input detected. Please try again.",
+                colour=WallEColour.ERROR
+            )
+            await self.send_message_to_user_or_bot_channel(e_obj, interaction, delete_response=True)
             return
         try:
             await interaction.response.defer()


### PR DESCRIPTION
## Description

 1. Updating the general flow of the commands so it follows this logic:
    1. if there is an input, exit out if the input == -1
    2. defer the command in case there is a big server load and the function execution will take some time
    3. if the command is paginated, exit  out and alert the user to call the command from the bot_channel
    4. exit out if the input is not a digit when it should be
2. General updates to the functions responsible for determining where to send what message based on if its a paginated command or not
3. adding a better user response for situations like user selecting an invalid menu option as just erroring out is rather vague

## PR Checklist

> Make sure to account for all the items in the [PR checklist](https://github.com/CSSS/wall_e/wiki/4.-PR-Checklist)
