### PR TITLE
Updated SFU modules to slash cmds

### DIFF
--- a/wall_e/extensions/sfu.py
+++ b/wall_e/extensions/sfu.py
@@ -561,7 +561,7 @@ class SFU(commands.Cog):
         if department:
             departments = [department.upper()]
 
-        if level and (level < 100 or level >= 1000):
+        if level is not None and (level < 100 or level >= 1000):
             self.logger.debug("[SFU courses()] invalid level argument")
             desc = ("Invalid level argument. Level must be within 100 and 999.\n"
                     "Example: `/courses level:200`")
@@ -592,7 +592,7 @@ class SFU(commands.Cog):
 
                     # we assume all courses have 3 digits
                     course["value"] = int(course["value"][:3])
-                    if not level or (course["value"]//100 == level//100):
+                    if level is None or (course["value"]//100 == level//100):
                         courses.append(course)
             else:
                 self.logger.debug(f"[SFU courses()] get request for {department} resulted in {res.status}")

--- a/wall_e/extensions/sfu.py
+++ b/wall_e/extensions/sfu.py
@@ -517,6 +517,13 @@ class SFU(commands.Cog):
             f'[SFU courses()] courses command detected from user {interaction.user} with arguments: '
             f'department {department}, level {level}, term {term}, year {year}'
         )
+        try:
+            await interaction.response.defer()
+        except discord.errors.NotFound:
+            await interaction.channel.send(
+                "Feeling a bit overloaded at the moment...Please try again in a few minutes"
+            )
+            return
 
         # The default course selection if not specified
         departments = ['CMPT', 'MATH', 'MACM']
@@ -592,9 +599,9 @@ class SFU(commands.Cog):
                 colour=WallEColour.ERROR,
             )
             if e_obj:
-                await interaction.response.send_message(embed=e_obj)
+                msg = await interaction.followup.send(embed=e_obj)
                 await asyncio.sleep(10)
-                await interaction.delete_original_response()
+                await msg.delete()
             return
         else:
             await paginate_embed(

--- a/wall_e/extensions/sfu.py
+++ b/wall_e/extensions/sfu.py
@@ -552,6 +552,23 @@ class SFU(commands.Cog):
             else:
                 self.logger.debug(f"[SFU courses()] get request for {department} resulted in {res.status}")
 
+        if len(courses) == 0:
+            self.logger.debug("[SFU courses()] resulted in no content")
+            e_obj = await embed(
+                self.logger, interaction=interaction, title="SFU Courses Error",
+                description=(
+                    f"Couldn't find anything for `department: {', '.join(departments)}"
+                    f", level: {level if level != 0 else 'all'}, term: {term}, year: {year}`"
+                    f"\n Maybe no courses are being offered at that time."
+                ),
+                colour=WallEColour.ERROR,
+            )
+            if e_obj:
+                msg = await interaction.followup.send(embed=e_obj)
+                await asyncio.sleep(10)
+                await msg.delete()
+            return
+
         if len(departments) > 1:
             courses = sorted(courses, key=lambda k: k["value"])
 
@@ -581,28 +598,11 @@ class SFU(commands.Cog):
                  f" {f'{year.title()}' if year != 'registration' and year != 'current' else f'{year} year'}"
                  f"\n(Total Courses: {total_course})\n")
 
-        if len(content_to_embed) == 0:
-            self.logger.debug("[SFU courses()] resulted in no content")
-            e_obj = await embed(
-                self.logger, interaction=interaction, title="SFU Courses Error",
-                description=(
-                    f"Couldn't find anything for `department: {', '.join(departments)}"
-                    f", level: {level if level != 0 else 'all'}, term: {term}, year: {year}`"
-                    f"\n Maybe no courses are being offered at that time."
-                ),
-                colour=WallEColour.ERROR,
-            )
-            if e_obj:
-                msg = await interaction.followup.send(embed=e_obj)
-                await asyncio.sleep(10)
-                await msg.delete()
-            return
-        else:
-            await paginate_embed(
-                self.logger, bot, content_to_embed=content_to_embed,
-                title=title,
-                interaction=interaction
-            )
+        await paginate_embed(
+            self.logger, bot, content_to_embed=content_to_embed,
+            title=title,
+            interaction=interaction
+        )
 
     async def cog_unload(self) -> None:
         await self.req.close()

--- a/wall_e/extensions/sfu.py
+++ b/wall_e/extensions/sfu.py
@@ -517,13 +517,7 @@ class SFU(commands.Cog):
             f"[SFU courses()] courses command detected from user {interaction.user} with arguments: "
             f"department {department}, level {level}, term {term}, year {year}"
         )
-        try:
-            await interaction.response.defer()
-        except discord.errors.NotFound:
-            await interaction.channel.send(
-                "Feeling a bit overloaded at the moment...Please try again in a few minutes"
-            )
-            return
+        await interaction.response.defer()
 
         # The default course selection if not specified
         departments = ["CMPT", "MATH", "MACM"]
@@ -568,14 +562,14 @@ class SFU(commands.Cog):
         total_course = 0
         content = ""
 
-        for course in courses:
+        for i, course in enumerate(courses):
             course_title = course["title"]
             course_number = course["text"]
             content += f"\n{course_number} - {course_title}"
 
             total_course += 1
             number_of_courses += 1
-            if total_course > 0 and (number_of_courses % number_of_courses_per_page == 0 or course is courses[-1]):
+            if total_course > 0 and (number_of_courses % number_of_courses_per_page == 0 or i == len(courses) - 1):
                 number_of_courses = 0
                 content_to_embed.append(
                     [["Code - Title", content]]

--- a/wall_e/extensions/sfu.py
+++ b/wall_e/extensions/sfu.py
@@ -512,10 +512,10 @@ class SFU(commands.Cog):
     @app_commands.describe(term="Specify the specific semester to search for. Examples: Spring, Summer, Fall")
     @app_commands.describe(year="Specify the specific year to search for. Examples: 2020, 2024, 2025")
     async def courses(self, interaction: discord.Interaction, department: str = "", level: int = 0,
-                  term: str = "registration", year: str = "registration"):
+                      term: str = "registration", year: str = "registration"):
         self.logger.info(
-            f'[SFU courses()] courses command detected from user {interaction.user} with arguments: '
-            f'department {department}, level {level}, term {term}, year {year}'
+            f"[SFU courses()] courses command detected from user {interaction.user} with arguments: "
+            f"department {department}, level {level}, term {term}, year {year}"
         )
         try:
             await interaction.response.defer()
@@ -526,42 +526,42 @@ class SFU(commands.Cog):
             return
 
         # The default course selection if not specified
-        departments = ['CMPT', 'MATH', 'MACM']
+        departments = ["CMPT", "MATH", "MACM"]
         if department:
             departments = [department.upper()]
 
         if level != 0 and (level < 100 or level >= 1000):
-            self.logger.debug(f'[SFU courses()] incorrect level arguments, defaulting to 0')
+            self.logger.debug("[SFU courses()] incorrect level arguments, defaulting to 0")
             level = 0
 
         courses = []
         for department in departments:
-            url = f'http://www.sfu.ca/bin/wcm/course-outlines?{year}/{term}/{department}/'
-            self.logger.debug(f'[SFU courses()] url for get constructed: {url}')
+            url = f"http://www.sfu.ca/bin/wcm/course-outlines?{year}/{term}/{department}/"
+            self.logger.debug(f"[SFU courses()] url for get constructed: {url}")
 
             res = await self.req.get(url)
             if res.status == 200:
-                self.logger.debug(f'[SFU courses()] get request for {department} successful, parsing data')
+                self.logger.debug(f"[SFU courses()] get request for {department} successful, parsing data")
                 res_json = await res.json()
 
                 # parse data for displaying, sorting, and filtering
                 for course in res_json:
-                    course['text'] = f"{department}{course['text']}"
+                    course["text"] = f"{department}{course['text']}"
 
                     # we assume all courses have 3 digits
-                    if len(course['value']) == 4:
-                        course['value'] = course['value'][:3]
+                    if len(course["value"]) == 4:
+                        course["value"] = course["value"][:3]
 
-                    course['value'] = int(course['value'])
-                    if level == 0 or (course['value']//100 == level//100):
+                    course["value"] = int(course["value"])
+                    if level == 0 or (course["value"]//100 == level//100):
                         courses.append(course)
             else:
-                self.logger.debug(f'[SFU courses()] get request for {department} resulted in {res.status}')
+                self.logger.debug(f"[SFU courses()] get request for {department} resulted in {res.status}")
 
         if len(departments) > 1:
-            courses = sorted(courses, key=lambda k: k['value'])
+            courses = sorted(courses, key=lambda k: k["value"])
 
-        self.logger.debug('[SFU courses()] parsing data from get request')
+        self.logger.debug("[SFU courses()] parsing data from get request")
         content_to_embed = []
         number_of_courses_per_page = 20
         number_of_courses = 0
@@ -569,8 +569,8 @@ class SFU(commands.Cog):
         content = ""
 
         for course in courses:
-            course_title = course['title']
-            course_number = course['text']
+            course_title = course["title"]
+            course_number = course["text"]
             content += f"\n{course_number} - {course_title}"
 
             total_course += 1
@@ -588,13 +588,13 @@ class SFU(commands.Cog):
                  f"\n(Total Courses: {total_course})\n")
 
         if len(content_to_embed) == 0:
-            self.logger.debug(f'[SFU courses()] resulted in no content')
+            self.logger.debug("[SFU courses()] resulted in no content")
             e_obj = await embed(
-                self.logger, interaction=interaction, title='SFU Courses Error',
+                self.logger, interaction=interaction, title="SFU Courses Error",
                 description=(
-                    f'Couldn\'t find anything for `department: {", ".join(departments)}'
-                    f', level: {level if level != 0 else "all"}, term: {term}, year: {year}`'
-                    f'\n Maybe no courses are being offered at that time.'
+                    f"Couldn't find anything for `department: {', '.join(departments)}"
+                    f", level: {level if level != 0 else 'all'}, term: {term}, year: {year}`"
+                    f"\n Maybe no courses are being offered at that time."
                 ),
                 colour=WallEColour.ERROR,
             )
@@ -609,7 +609,6 @@ class SFU(commands.Cog):
                 title=title,
                 interaction=interaction
             )
-
 
     async def cog_unload(self) -> None:
         await self.req.close()

--- a/wall_e/extensions/sfu.py
+++ b/wall_e/extensions/sfu.py
@@ -523,7 +523,7 @@ class SFU(commands.Cog):
         if department:
             departments = [department.upper()]
 
-        if level != 0 and (level < 100 or level > 1000):
+        if level != 0 and (level < 100 or level >= 1000):
             self.logger.debug(f'[SFU courses()] incorrect level arguments, defaulting to 0')
             level = 0
 
@@ -575,7 +575,7 @@ class SFU(commands.Cog):
                 )
                 content = ""
 
-        title = (f"{', '.join(departments)} {f'{level} level -' if level != 0 else '-'}"
+        title = (f"{', '.join(departments)} {f'{(level//100)*100} level -' if level != 0 else '-'}"
                  f" {f'{term.title()}' if term != 'registration' and term != 'current' else f'{term} term'}"
                  f" {f'{year.title()}' if year != 'registration' and year != 'current' else f'{year} year'}"
                  f"\n(Total Courses: {total_course})\n")
@@ -585,7 +585,7 @@ class SFU(commands.Cog):
             e_obj = await embed(
                 self.logger, interaction=interaction, title='SFU Courses Error',
                 description=(
-                    f'Couldn\'t find anything for `{", ".join(departments)}'
+                    f'Couldn\'t find anything for `department: {", ".join(departments)}'
                     f', level: {level if level != 0 else "all"}, term: {term}, year: {year}`'
                     f'\n Maybe no courses are being offered at that time.'
                 ),


### PR DESCRIPTION
### EDIT: mistakenly pushed a different issues code into this branch, please ignore this PR

## Description

In regard to issue [#667](https://github.com/CSSS/wall_e/issues/667)

Converted `def sfu()` and `def outline()` to slash commands. Also rewrote existing commands to be more clean and DRY.

## Things to Note:

- **For `outline()`, I am unsure how to have the optional argument “next”, current setup as an input argument called `arg`** 
- There may be a better way to chunk `_construct_fields()`
- `_construct_fields()` could not use the `info` and `schedule` arguments, however it would require `interaction` to embed an error message. Unsure which is better
- For `_split_course`, I return an error using a third return value, there may be a better way to do this
- Image for thumbnail seems to be broken, so I removed it
- Room always seems to be TBD
- Apparently we do not need to use the json library since we can just use request library, I am unsure how while chunking the data
- **For the `courses()` function, it does not chunk the get request, could be a concern**

## PR Checklist

All test cases done in the [test cases section](https://github.com/CSSS/wall_e/blob/master/Test_Cases.md) are passed except for required arguments now being shown in the Discord UI due to the command being converted from `.` to `/`